### PR TITLE
Fix(eos_cli_config_gen): Render VRRP tracked-objects for POs

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -6889,9 +6889,13 @@ interface Port-Channel333
    vrrp 1 ipv4 192.0.2.1
    vrrp 1 ipv4 192.0.3.3 secondary
    vrrp 1 ipv4 192.0.4.4 secondary
+   vrrp 1 tracked-object ID1TrackedObjectDecrement decrement 5
+   vrrp 1 tracked-object ID1TrackedObjectShutdown shutdown
    vrrp 2 peer authentication text <removed>
    vrrp 2 ipv6 2001:db8:333::1
    vrrp 2 ipv6 2002:db8:333::2
+   vrrp 2 tracked-object ID2TrackedObjectDecrement decrement 10
+   vrrp 2 tracked-object ID2TrackedObjectShutdown shutdown
    no vrrp 3 preempt
    vrrp 3 timers delay reload 900
    vrrp 3 ipv4 100.64.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2780,9 +2780,13 @@ interface Port-Channel333
    vrrp 1 ipv4 192.0.2.1
    vrrp 1 ipv4 192.0.3.3 secondary
    vrrp 1 ipv4 192.0.4.4 secondary
+   vrrp 1 tracked-object ID1TrackedObjectDecrement decrement 5
+   vrrp 1 tracked-object ID1TrackedObjectShutdown shutdown
    vrrp 2 peer authentication text auth_key
    vrrp 2 ipv6 2001:db8:333::1
    vrrp 2 ipv6 2002:db8:333::2
+   vrrp 2 tracked-object ID2TrackedObjectDecrement decrement 10
+   vrrp 2 tracked-object ID2TrackedObjectShutdown shutdown
    no vrrp 3 preempt
    vrrp 3 timers delay reload 900
    vrrp 3 ipv4 100.64.0.1

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -954,5 +954,14 @@ interface {{ port_channel_interface.name }}
 {%         elif vrid.ipv6.address is arista.avd.defined %}
    vrrp {{ vrid.id }} ipv6 {{ vrid.ipv6.address }}
 {%         endif %}
+{%         for tracked_obj in vrid.tracked_object | arista.avd.natural_sort(sort_key='name', ignore_case=false) %}
+{%             set tracked_obj_cli = "vrrp " ~ vrid.id ~ " tracked-object " ~ tracked_obj.name %}
+{%             if tracked_obj.decrement is arista.avd.defined %}
+{%                 set tracked_obj_cli = tracked_obj_cli ~ " decrement " ~ tracked_obj.decrement %}
+{%             elif tracked_obj.shutdown is arista.avd.defined(true) %}
+{%                 set tracked_obj_cli = tracked_obj_cli ~ " shutdown" %}
+{%             endif %}
+   {{ tracked_obj_cli }}
+{%         endfor %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Adjust EOS PO J2 to render VRRP tracked-objects

## Related Issue(s)

Fixes #6434 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Adjust EOS J2 template for PO. Ethernet/SVI templates are OK

## How to test
Molecule scenario `eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
