### PR TITLE
Refactor: Fix deprecation warning in global_vars for ansible-core >= 2.19

### DIFF
--- a/ansible_collections/arista/avd/plugins/vars/global_vars.py
+++ b/ansible_collections/arista/avd/plugins/vars/global_vars.py
@@ -89,7 +89,7 @@ from typing import Any
 from ansible.errors import AnsibleParserError
 from ansible.inventory.group import Group
 from ansible.inventory.host import Host
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import to_native
 from ansible.plugins.vars import BaseVarsPlugin
 from ansible.utils.vars import combine_vars
 


### PR DESCRIPTION
## Change Summary

one import in global vars is triggering deprecation warning and was missed because of https://github.com/ansible/ansible/issues/85436 

## Related Issue(s)

Reported from the field

## Component(s) name

`arista.avd.global_vars`

## Proposed changes

Move to new location for the import like we do in pyavd_wrapper

## How to test

Test using ansible-core > 2.19 to run in devel

```
cd ansible_collections/arista/avd/tests/integration/targets/vars_global_vars
# Run the playbook outside of integration tests to get the deprecation
ansible-playbook -i hosts.yml playbook.yml

# [DEPRECATION WARNING]: Importing 'to_native' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
```

Then do the same in this PR. The warning is gone

Tested locally for 2.16 & 2.17 and this still works with the new import.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
