### PR TITLE
Feat(pyavd): Add get_device_config_tree helper

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -603,13 +603,15 @@ jobs:
             id: Main-Tests
             pytest_args: >-
               --ignore=python-avd/tests/pyavd/molecule_scenarios/test_get_device_config.py
+              --ignore=python-avd/tests/pyavd/molecule_scenarios/test_get_device_config_tree.py
               --ignore=python-avd/tests/pyavd/molecule_scenarios/test_negative_eos_designs.py
               --ignore=python-avd/tests/schema_tools/metaschema/test_meta_schema_model.py
             upload_compiled_templates: true
-          - name: "Excluded-Tests (test_get_device_config and test_meta_schema_model)"
+          - name: "Excluded-Tests (test_get_device_config, test_get_device_config_tree and test_meta_schema_model)"
             id: Excluded-test_get_device_config-and-test_meta_schema_model
             pytest_args: >-
               python-avd/tests/pyavd/molecule_scenarios/test_get_device_config.py
+              python-avd/tests/pyavd/molecule_scenarios/test_get_device_config_tree.py
               python-avd/tests/schema_tools/metaschema/test_meta_schema_model.py
           - name: "Excluded-Tests (test_negative_eos_designs)"
             id: Excluded-test_negative_eos_designs

--- a/python-avd/pyavd/__init__.py
+++ b/python-avd/pyavd/__init__.py
@@ -3,6 +3,7 @@
 # that can be found in the LICENSE file.
 from .get_avd_facts import get_avd_facts
 from .get_device_config import get_device_config
+from .get_device_config_tree import get_device_config_tree
 from .get_device_doc import get_device_doc
 from .get_device_structured_config import get_device_structured_config
 from .get_device_test_catalog import get_device_test_catalog
@@ -23,6 +24,7 @@ __version__ = "6.0.0.dev7"
 __all__ = [
     "get_avd_facts",
     "get_device_config",
+    "get_device_config_tree",
     "get_device_doc",
     "get_device_structured_config",
     "get_device_test_catalog",

--- a/python-avd/pyavd/get_device_config_tree.py
+++ b/python-avd/pyavd/get_device_config_tree.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023-2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .api.schemas import EOSConfig
+
+
+def get_device_config_tree(structured_config: EOSConfig | dict) -> dict[str, dict]:
+    """
+    Render eos_cli_config_gen templates and return a nested dict representing the CLI.
+
+    Args:
+        structured_config:
+            EOSConfig instance or dictionary with the validated structured configuration.
+
+    Returns:
+        Device configuration as a nested dict under a single 'default' key.
+    """
+    from .get_device_config import get_device_config  # noqa: PLC0415
+
+    full_cli = get_device_config(structured_config)
+
+    # Convert the full CLI into a nested dictionary
+    return {"default": _cli_to_tree(full_cli)}
+
+
+def _cli_to_tree(cli: str) -> dict[str, dict]:
+    """
+    Convert EOS CLI text into a nested dictionary using indentation.
+
+    Each command becomes a key in the dictionary, and subcommands are nested dictionaries.
+    """
+    tree: dict[str, dict] = {}
+    stack: list[tuple[int, dict[str, dict]]] = [(0, tree)]
+
+    for line in cli.splitlines():
+        stripped = line.lstrip()
+
+        # Ignore empty lines and comments
+        if not stripped or stripped.startswith("!"):
+            continue
+
+        indent = len(line) - len(stripped)
+
+        # Pop stack until we find the correct parent based on indentation
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+
+        parent = stack[-1][1] if stack else tree
+        parent[stripped] = {}
+        stack.append((indent, parent[stripped]))
+
+    return tree

--- a/python-avd/tests/pyavd/molecule_scenarios/test_get_device_config_tree.py
+++ b/python-avd/tests/pyavd/molecule_scenarios/test_get_device_config_tree.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+
+import pytest
+
+from pyavd import get_device_config_tree, validate_structured_config
+from pyavd._utils import get
+from tests.models import MoleculeHost
+
+
+@pytest.mark.molecule_scenarios(
+    "digital_twin",
+    "eos_designs_unit_tests",
+    "eos_designs_deprecated_vars",
+    "eos_cli_config_gen",
+    "eos_cli_config_gen_deprecated_vars",
+    "eos_designs-l2ls",
+    "eos_designs-mpls-isis-sr-ldp",
+    "eos_designs-twodc-5stage-clos",
+    "evpn_underlay_ebgp_overlay_ebgp",
+    "evpn_underlay_isis_overlay_ibgp",
+    "evpn_underlay_ospf_overlay_ebgp",
+    "evpn_underlay_rfc5549_overlay_ebgp",
+    "example-campus-fabric",
+    "example-dual-dc-l3ls",
+    "example-isis-ldp-ipvpn",
+    "example-l2ls-fabric",
+    "example-single-dc-l3ls",
+    "example-single-dc-l3ls-ipv6",
+)
+@pytest.mark.digital_twin_molecule_scenarios("eos_designs-twodc-5stage-clos", "digital_twin")
+def test_get_device_config_tree(molecule_host: MoleculeHost) -> None:
+    """Test get_device_config_tree."""
+    structured_config = molecule_host.hostvars if molecule_host.scenario.name.startswith("eos_cli_config_gen") else molecule_host.structured_config
+
+    if not get(structured_config, "eos_cli_config_gen_configuration.enable", default=True):
+        return
+
+    validated_data_result = validate_structured_config(structured_config)
+    assert validated_data_result.validated_data is not None
+    device_config_tree = get_device_config_tree(validated_data_result.validated_data)
+
+    assert isinstance(device_config_tree, dict)
+    assert "default" in device_config_tree
+
+    assert isinstance(device_config_tree["default"], dict)
+    assert len(device_config_tree["default"]) > 0


### PR DESCRIPTION
## Change Summary

Add get_device_config_tree() to pyavd to return rendered device CLI as a nested dictionary (with tests).
Enables structured inspection and downstream processing of generated EOS configurations.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
