### PR TITLE
Fix(eos_designs)!: Set RTC 'default-route-target only' on EVPN gateway also being route-server

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_gateway_l2_evpn_role_server.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_gateway_l2_evpn_role_server.cfg
@@ -203,6 +203,7 @@ router bgp 65233
       neighbor EVPN-OVERLAY-CORE activate
       neighbor EVPN-OVERLAY-CORE default-route-target only
       neighbor EVPN-OVERLAY-PEERS activate
+      neighbor EVPN-OVERLAY-PEERS default-route-target only
    !
    vrf VRF10
       rd 192.168.255.3:10

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_gateway_l2_evpn_role_server.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_gateway_l2_evpn_role_server.yml
@@ -226,6 +226,8 @@ router_bgp:
         only: true
     - name: EVPN-OVERLAY-PEERS
       activate: true
+      default_route_target:
+        only: true
   address_family_ipv4:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/router_bgp.py
@@ -378,14 +378,11 @@ class RouterBgpMixin(Protocol):
                 peer_group_obj = EosCliConfigGen.RouterBgp.AddressFamilyRtc.PeerGroupsItem(
                     name=self.inputs.bgp_peer_groups.evpn_overlay_core.name, activate=True
                 )
-                # TODO: (@Claus) told me to remove this
                 if self.shared_utils.evpn_role == "server":
                     peer_group_obj.default_route_target.only = True
                 peer_groups.append(peer_group_obj)
 
-            # Transposing the Jinja2 logic: if the evpn_overlay_core peer group is not
-            # configured then the default_route_target is applied in the evpn_overlay_peers peer group.
-            elif self.shared_utils.evpn_role == "server":
+            if self.shared_utils.evpn_role == "server":
                 peer_groups_evpn.default_route_target.only = True
 
         if self.shared_utils.overlay_routing_protocol == "ibgp":


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Set RTC 'default-route-target only' on EVPN gateway also being route-server

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- The combination of EVPN route-server and EVPN gateway and RTC did not configure
  RTC correctly on the peer-group towards EVPN clients.
- With this change the peer-group is always configured with `default-route-target only` if RTC enabled on a route-server

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing test shows the change.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
