### PR TITLE
CI: Updated collection mainfest to exclude extensions instead of molecule

### DIFF
--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -64,7 +64,7 @@ manifest:
     - recursive-include plugins **.py **.yml **.yaml
     - recursive-exclude changelogs/fragments_backup **
     - recursive-include examples **
-    - recursive-exclude molecule **
+    - recursive-exclude extensions **
     - include requirements.yml
     - include pylintrc
     - include pytest.ini


### PR DESCRIPTION
## Change Summary

Updated collection mainfest for exclude extensions instead of molecule

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Updated collection mainfest for exclude extensions instead of molecule

## How to test
Run `make collection-build` and check the the extension file should not be there.
```
(avd_env) mahesh.kumar-ext@Maheshs-MacBook-Pro avd % tar -tzf arista-avd-6.0.0-dev7.tar.gz | grep extensions                                   
tests/unit/extensions/
tests/unit/extensions/scripts/
tests/unit/extensions/scripts/test_processor.py
```


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
