### PR TITLE
CI: Fix ansible-lint issues on howto scenario

### DIFF
--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -12,3 +12,5 @@ exclude_paths:
   # Excluding task files depending on other collections since ansible-lint is running in offline mode on galaxy/automation hub
   - roles/eos_config_deploy_eapi/tasks/main.yml
   - roles/eos_snapshot/tasks/main.yml
+  # Excluding Molecule artifacts configuration file (not a playbook)
+  - extensions/molecule/howto/artifacts.yml

--- a/ansible_collections/arista/avd/extensions/molecule/howto/side_effect.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/side_effect.yml
@@ -10,22 +10,22 @@
 
   tasks:
     - name: Sanity check - config exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ config_file }}"
       register: cfg_stat
 
     - name: Fail if config is missing
-      fail:
+      ansible.builtin.fail:
         msg: "Config not found at {{ config_file }}"
       when: not cfg_stat.stat.exists
 
     - name: Execute Config Parser for EOS Artifacts
       # Syntax: python3 <script> <config_input>
       # Each artifact in the config specifies its own output_dir
-      command: "python3 {{ script_path }} {{ config_file }}"
+      ansible.builtin.command: "python3 {{ script_path }} {{ config_file }}"
       register: parser_output
       changed_when: false
 
     - name: Show Parser Output
-      debug:
+      ansible.builtin.debug:
         msg: "{{ parser_output.stdout_lines }}"


### PR DESCRIPTION
## Change Summary

We are not checking these anymore in CI because we run ansible-lint against the built colleciton which does not include molecule. We could add back as step but I don't know if it is worth it.

## Proposed changes

Fixed the fix issues:

```
WARNING  Listing 5 violation(s) that are fatal
syntax-check[specific]: 'file' is not a valid attribute for a Play
extensions/molecule/howto/artifacts.yml:3:3

fqcn[action-core]: Use FQCN for builtin module actions (stat).
extensions/molecule/howto/side_effect.yml:13:7 Use `ansible.builtin.stat` or `ansible.legacy.stat` instead.

fqcn[action-core]: Use FQCN for builtin module actions (fail).
extensions/molecule/howto/side_effect.yml:18:7 Use `ansible.builtin.fail` or `ansible.legacy.fail` instead.

fqcn[action-core]: Use FQCN for builtin module actions (command).
extensions/molecule/howto/side_effect.yml:25:7 Use `ansible.builtin.command` or `ansible.legacy.command` instead.

fqcn[action-core]: Use FQCN for builtin module actions (debug).
extensions/molecule/howto/side_effect.yml:30:7 Use `ansible.builtin.debug` or `ansible.legacy.debug` instead.
```

## How to test

run `ansible-lint` and check there is no more problem

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
