### PR TITLE
Doc: Updating 5.7.3 release-notes

### DIFF
--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -34,7 +34,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | `avd_data_validation_mode` | - | Validation is always required. |
 | `avd_eos_designs_debug` | `eos_designs_keep_tmp_files` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
-| `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `eos_designs_tmp_dir` and `eos_cli_config_gen_tmp_dir`. |
+| `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. The facts can be read from the tmp file by setting `eos_designs_keep_tmp_files: true`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |
 | `wan_use_evpn_node_settings_for_lan` | - | Default in AVD 6.0 |
 

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -32,7 +32,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | Deprecated key | New key in AVD 6.0 | Notes for AVD 6.0 |
 | -------------- | ------------------ | ----------------- |
 | `avd_data_validation_mode` | - | Validation is always required. |
-| `avd_eos_designs_debug` | `eos_designs_keep_tmp_files` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
+| `avd_eos_designs_debug` | `eos_designs_keep_tmp_files` | Prevents cleaning up the temporary files stored in the directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
 | `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. The facts can be read from the tmp file by setting `eos_designs_keep_tmp_files: true`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -34,7 +34,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | `avd_data_validation_mode` | - | Validation is always required. |
 | `avd_eos_designs_debug` | `eos_designs_keep_tmp_files` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
-| `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `avd_tmp_dir`. |
+| `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `eos_designs_tmp_dir` and `eos_cli_config_gen_tmp_dir`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |
 | `wan_use_evpn_node_settings_for_lan` | - | Default in AVD 6.0 |
 

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -32,7 +32,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | Deprecated key | New key in AVD 6.0 | Notes for AVD 6.0 |
 | -------------- | ------------------ | ----------------- |
 | `avd_data_validation_mode` | - | Validation is always required. |
-| `avd_eos_designs_debug` | avd_tmp_dir | AVD will output internal temporary files to `avd_tmp_dir` containing validated variables and facts. |
+| `avd_eos_designs_debug` | `avd_debug` | Enable debug mode for AVD. In debug mode, the AVD temporary directory defined by `avd_tmp_dir` is not cleaned up at the end of each role. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
 | `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `avd_tmp_dir`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -32,7 +32,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | Deprecated key | New key in AVD 6.0 | Notes for AVD 6.0 |
 | -------------- | ------------------ | ----------------- |
 | `avd_data_validation_mode` | - | Validation is always required. |
-| `avd_eos_designs_debug` | `avd_debug` | Enable debug mode for AVD. In debug mode, the AVD temporary directory defined by `avd_tmp_dir` is not cleaned up at the end of each role. |
+| `avd_eos_designs_debug` | `eos_designs_keep_tmp_files ` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
 | `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `avd_tmp_dir`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -32,7 +32,7 @@ The following data model keys have been deprecated from eos_designs in AVD 5.7.3
 | Deprecated key | New key in AVD 6.0 | Notes for AVD 6.0 |
 | -------------- | ------------------ | ----------------- |
 | `avd_data_validation_mode` | - | Validation is always required. |
-| `avd_eos_designs_debug` | `eos_designs_keep_tmp_files ` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
+| `avd_eos_designs_debug` | `eos_designs_keep_tmp_files` | Prevents cleaning up the temporary files generated internally by AVD plugins stored in the temporary directory defined by `eos_designs_tmp_dir`. Allows for inspecting templated inputs, validated inputs and facts. |
 | `avd_eos_designs_enforce_duplication_checks_across_all_models` | - | This is the builtin behavior. |
 | `avd_eos_designs_unset_facts` | - | `avd_switch_facts` are no longer set in Ansible. Can be read by setting `avd_tmp_dir`. |
 | `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` | `<node_type>.kernel_ecmp_cli` | Set new key to `false` to retain the behavior. |


### PR DESCRIPTION
## Change Summary

Updating 5.7.x release-notes to add avd_debug as a new key for avd_eos_designs_debug

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
