### PR TITLE
Doc: 6.0.0 Porting guides updates

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/parse_validation_result.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/parse_validation_result.py
@@ -49,7 +49,7 @@ def parse_validation_result(validation_result: ValidationResult, hostname: str, 
         message = (
             f"[{hostname}]: The EOS Config input key '{path}' is present in the input to 'eos_designs' and will be ignored. "
             f"To address this, use the equivalent AVD Design input model if available or use custom_structured_configuration. "
-            f"See https://avd.arista.com/6.x/docs/porting-guides/6.x.x.html#using-eos-config-inputs-eos_cli_config_gen-keys-when-running-eos_designs "
+            f"See https://avd.arista.com/6.x/docs/porting-guides/6.x.x.html#using-eos-config-eos_cli_config_gen-data-models-when-running-eos_designs"
             "for details."
         )
         ansible_display.warning(message, formatted=True)

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -23,9 +23,9 @@ Users of `eos_designs` need to consider the changes in `eos_cli_config_gen` when
 
 ## Common changes
 
-### All eos_designs and eos_cli_config_gen variables are always validated by schemas
+### Schema validation is enforced on all keys in Ansible role `eos_designs` and `eos_cli_config_gen`
 
-In AVD 6.0.0, all `eos_designs` and `eos_cli_config_gen` keys are validated by schemas and execution will stop for any violations.
+In AVD 6.0.0, schema validation is enforced on all keys in Ansible role `eos_designs` and `eos_cli_config_gen`. Execution will stop for any violations.
 If additional custom keys are desired, a key starting with an underscore `_` will be ignored by validation.
 
 It was previously possible to only warn about input schema violations, but this is no longer allowed.
@@ -36,9 +36,9 @@ It was previously possible to only warn about input schema violations, but this 
 
 ## Requirements changes
 
-### `ansible.utils` collection was removed from the `arista.avd` Ansible collection
+### The `ansible.utils` Ansible collection dependency was removed from the `arista.avd` Ansible collection
 
-Until 5.x, `ansible.utils` collection was a requirement of `arista.avd` Ansible collection.
+In AVD 5.x, `ansible.utils` collection was a requirement of the `arista.avd` Ansible collection.
 
 This has been removed in AVD 6.0.0. If you were using the `ansible.utils` collection functionalities in your playbooks or templates, you now need to add the installation
 of the collection to your environment. You will need to adjust your scripts to install your environment to add this collection.
@@ -49,9 +49,9 @@ As an example, you can install it in your environment using:
 ansible-galaxy collection install ansible.utils
 ```
 
-### Jinja2 extensions no longer needed in `ansible.cfg`
+### Jinja2 extensions are no longer needed in `ansible.cfg`
 
-Until 5.x, the AVD documentation indicated that it was necessary to configure some Jinja2 extensions in `ansible.cfg`
+In AVD 5.x, the AVD documentation indicated that it was necessary to configure some Jinja2 extensions in `ansible.cfg`
 This is no longer needed as the extensions are automatically loaded in `pyavd` when compiling the Jinja2 templates.
 
 ```diff
@@ -59,7 +59,7 @@ This is no longer needed as the extensions are automatically loaded in `pyavd` w
 -jinja2_extensions = jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
 ```
 
-### `anta` is now a core dependency of `pyavd`
+### The `anta` Python library is now a core dependency of `pyavd` Python package
 
 In AVD 6.0.0, the `anta` library has been promoted from an optional dependency (previously part of the `ansible-collection` extra) to a core requirement of `pyavd`.
 
@@ -94,9 +94,9 @@ was the output of `str` on each items. This could lead to inconsistent behavior 
 
 ## Changes to Ansible role arista.avd.eos_designs
 
-### Removal of deprecated eos_designs data models
+### Removal of deprecated AVD Design (eos_designs) data models
 
-The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
+The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0.
 
 | Removed key | New key |
 | ----------- | ------- |
@@ -161,9 +161,9 @@ The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
 | `underlay_mutlticast` | `underlay_mutlticast_pim_sm` or `<node_type_key>.defaults.underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].nodes[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.nodes[].underlay_multicast.pim_sm.enabled` |
 | `underlay_ospf_authentication.message_digest_keys[].key` | `underlay_ospf_authentication.message_digest_keys[].cleartext_key` |
 
-### New eos_designs schema restrictions
+### New AVD Design (eos_designs) schema restrictions
 
-Starting AVD 6.0.0, the following data model keys will have defined restrictions in `eos_designs`.
+Starting with AVD 6.0.0, the following data model keys will have defined restrictions in AVD Design (`eos_designs`).
 
 | Keys | New Restrictions |
 | ---- | ---------------- |
@@ -262,7 +262,7 @@ To retain access to these files, set `eos_designs_keep_tmp_files: true`. This pr
     Please refer to the [Ansible Vault documentation](https://docs.ansible.com/projects/ansible/latest/vault_guide/index.html) for more details.
 
 <!-- This title is used in an error message in the AVD collection, please do not edit! -->
-### Using EOS Config inputs (`eos_cli_config_gen`) keys when running `eos_designs`
+### Using EOS Config (`eos_cli_config_gen`) data models when running `eos_designs`
 
 For several AVD major versions, it has been possible to use variables from the EOS Config (`eos_cli_config_gen`) data model in conjunction with variables from the AVD Design (`eos_designs`) data model.
 When the `eos_designs` role runs, the EOS Config (`eos_cli_config_gen`) keys were ignored but they were read later by the `eos_cli_config_gen` role.
@@ -387,138 +387,16 @@ fatal: [mlag-leaf-1 -> localhost]: FAILED! => {"changed": false, "msg": "Found d
 'metadata': {'peer': 'mlag-leaf-2', 'peer_interface': 'Ethernet3', 'peer_type': 'mlag_peer'}}."}
 ```
 
-### Removal of design.type
+### Removal of the `design.type` key
 
-In AVD 5.x, the variable `design.type` was used to select between different variants of default values for `node_type_keys`.
+In AVD 5.x, the key `design.type` was used to select between different variants of default values for `node_type_keys`.
 
-As of AVD 6.x, the `design.type` variable has been removed. The default values of `node_type_keys` combine all the default node type from all designs.
+As of AVD 6.x, the `design.type` key has been removed. The default values of `node_type_keys` combine all the default node type from all designs.
 
 ```diff
 # Remove the design.type setting
 - design:
 -   type: l2ls
-```
-
-### Change in data model for DNS name servers `name_servers`
-
-In AVD 5.x, DNS name servers were configured using the top-level key `name_servers`.
-
-Starting with AVD 6.0.0, the `name_servers` data model has been replaced by `dns_settings.servers`, which uses a structured format to define DNS server IP addresses.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-- name_servers:
--   - 192.168.200.5
--   - 8.8.8.8
-+ dns_settings:
-+   servers:
-+     - ip_address: 192.168.200.5
-+     - ip_address: 8.8.8.8
-```
-
-### The default value for `snmp_settings.compute_local_engineid_source` is now `rfc3411_type5`
-
-In AVD 5.x, the default value of `snmp_settings.compute_local_engineid_source` was `hostname_and_ip`. This method has several issues;
-firstly the method is not using the inband management IP, even if no management interface IP is set, and secondly the resulting Engine ID is not compliant with the RFC3411 format.
-
-Starting with AVD 6.0.0, the default value has been changed to `rfc3411_type5`. This now generates a RFC3411 Type 5 compliant engine ID and handles the inband management IP cases properly.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-snmp_settings:
-+  compute_local_engineid_source: hostname_and_ip
-```
-
-### Change in SNMP data model from `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf` to `snmp_settings.vrfs[]`
-
-In AVD 5.x, SNMP could be enabled on special management VRFs using `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf`.
-
-Starting with AVD 6.0.0, these keys have been removed. SNMP VRFs must now be explicitly defined under `snmp_settings.vrfs` with the proper name and enable field.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-snmp_settings:
-- enable_inband_mgmt_vrf: true
-- enable_mgmt_interface_vrf: true
-+ vrfs:
-+   - name: use_inband_mgmt_vrf
-+     enable: true
-+   - name: use_mgmt_interface_vrf
-+     enable: true
-```
-
-### SNMP `snmp-server` IPv4 and IPv6 ACLs are now only configured when the VRF is enabled under `snmp_settings.vrfs`
-
-In AVD 5.x, SNMP `snmp-server` IPv4 and IPv6 ACLs were rendered even when the VRF was not enabled under `snmp_settings.vrfs`.
-
-Starting AVD 6.0.0, it is required to set `enable: true` under the VRF in order to render IPV4 and IPV6 ACLs or use `custom_structured_config`.
-
-```diff
-snmp_settings:
-   vrfs:
-    - name: Test_VRF
-+     enable: true
-      ipv4_acl: IPV4
-```
-
-### Changes in local user structured configuration for `no_password` and `disabled`
-
-In AVD 5.x.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
-
-Starting AVD 6.0.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
-
-### eAPI is not enabled by default anymore in eos_designs
-
-In previous versions, `management_eapi.enabled` was `true` by default.
-
-In AVD 6.0.0, this is not the case anymore and eAPI needs to be explicitly enabled as follows:
-
-```diff
-management_eapi:
-+ enabled: true
-  enable_https: true
-```
-
-### A management IP or IPv6 is now required to enable eAPI when `default_mgmt_method: oob`
-
-Before AVD 6.x, it was possible to enable eAPI without setting `mgmt_ip` or `ipv6_mgmt_ip` when the default management method was set to out-of-band (which is the default) `default_mgmt_method: oob` and `management_eapi.vrfs` was not set.
-
-Starting AVD 6.0.0, enabling eAPI when the default management method is set to `oob` and `management_eapi.vrfs` is not set will raise an error if neither `mgmt_ip` nor `ipv6_mgmt_ip` are defined.
-Below changes should be noted to migrate to AVD 6.0.0 without errors.
-
-```diff
-type: l2leaf
-
-management_eapi:
-+ enabled: true # This must be set for management_eapi to take effect.
-  enable_https: true
-
-l2leaf:
-  nodes:
-    - name: management-eapi-host
-      id: 1
-+     mgmt_ip: 10.10.10.1/8
-```
-
-### Default management interface changed for cEOS platforms
-
-Starting AVD 6.0.0, the default management interface for cEOS and cEOSLab platforms has been changed from `Management0` to `Management1`.
-
-This change was made because `Management0` in EOS is handled as a virtual interface used in chassis, which limits the possible configuration on it.
-
-If you need to continue using `Management0` for cEOS platforms, you can override this using `custom_platform_settings`:
-
-```diff
-+custom_platform_settings:
-+  - platforms:
-+      - CEOS
-+      - cEOS
-+      - ceos
-+      - cEOSLab
-+    management_interface: Management0
 ```
 
 ### Migrating from CloudVision keys to `cv_settings`
@@ -572,13 +450,13 @@ These keys are now removed and replaced with `cv_settings`, to build a similar o
     ```
 
 !!! note
-    The example above leverages the built-in defaults, if you would like to override any settings, please refer to the "New key" listed in the [removal of deprecated eos_designs data-models table](#removal-of-deprecated-eos_designs-data-models).
+    The example above leverages the built-in defaults, if you would like to override any settings, please refer to the "New key" listed in the [Removal of deprecated AVD Design (eos_designs) data models](#removal-of-deprecated-avd-design-eos_designs-data-models) section below.
 
 ### Changes in validation requirements for CloudVision clusters
 
 In AVD 5.x.x, CloudVision clusters could be configured without enforcing the presence of NTP or DNS settings, even when servers were defined using DNS names.
 
-Starting AVD 6.0.0, additional validation is enforced when CloudVision clusters (on-prem or CVaaS) are configured:
+Starting with AVD 6.0.0, additional validation is enforced when CloudVision clusters (on-prem or CVaaS) are configured:
 
 - `ntp_settings.servers` must be configured whenever any CloudVision cluster `cv_settings.cvaas.clusters[]` or `cv_settings.onprem_clusters[].servers[]` are defined.
 - `dns_settings.servers` must be configured when CVaaS clusters `cv_settings.cvaas.clusters[]` are defined.
@@ -614,6 +492,128 @@ cv_topology:
 ```
 
 See the [documentation](../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#cloudvision-topology-settings) for `cv_topology` for details on the new behavior.
+
+### Change in data model for DNS name servers `name_servers`
+
+In AVD 5.x, DNS name servers were configured using the top-level key `name_servers`.
+
+Starting with AVD 6.0.0, the `name_servers` data model has been replaced by `dns_settings.servers`, which uses an improved data model to define DNS server attributes such as IP addresses.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+- name_servers:
+-   - 192.168.200.5
+-   - 8.8.8.8
++ dns_settings:
++   servers:
++     - ip_address: 192.168.200.5
++     - ip_address: 8.8.8.8
+```
+
+### The default value for `snmp_settings.compute_local_engineid_source` is now `rfc3411_type5`
+
+In AVD 5.x, the default value of `snmp_settings.compute_local_engineid_source` was `hostname_and_ip`. This method has several issues;
+firstly the method is not using the inband management IP, even if no management interface IP is set, and secondly the resulting Engine ID is not compliant with the RFC3411 format.
+
+Starting with AVD 6.0.0, the default value has been changed to `rfc3411_type5`. This now generates a RFC3411 Type 5 compliant engine ID and handles the inband management IP cases properly.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+snmp_settings:
++  compute_local_engineid_source: hostname_and_ip
+```
+
+### Change in SNMP data model from `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf` to `snmp_settings.vrfs[]`
+
+In AVD 5.x, SNMP could be enabled on special management VRFs using `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf`.
+
+Starting with AVD 6.0.0, these keys have been removed. SNMP VRFs must now be explicitly defined under `snmp_settings.vrfs` with the proper name and enable field.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+snmp_settings:
+- enable_inband_mgmt_vrf: true
+- enable_mgmt_interface_vrf: true
++ vrfs:
++   - name: use_inband_mgmt_vrf
++     enable: true
++   - name: use_mgmt_interface_vrf
++     enable: true
+```
+
+### SNMP `snmp-server` IPv4 and IPv6 ACLs are now only configured when the VRF is enabled under `snmp_settings.vrfs`
+
+In AVD 5.x, SNMP `snmp-server` IPv4 and IPv6 ACLs were rendered even when the VRF was not enabled under `snmp_settings.vrfs`.
+
+Starting with AVD 6.0.0, it is required to set `enable: true` under the VRF in order to render IPV4 and IPV6 ACLs or use `custom_structured_config`.
+
+```diff
+snmp_settings:
+   vrfs:
+    - name: Test_VRF
++     enable: true
+      ipv4_acl: IPV4
+```
+
+### Changes in local user structured configuration for `no_password` and `disabled`
+
+In AVD 5.x.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
+
+Starting with AVD 6.0.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
+
+### eAPI is not enabled by default anymore in eos_designs
+
+In previous versions, `management_eapi.enabled` was `true` by default.
+
+In AVD 6.0.0, eAPI needs to be explicitly enabled as follows:
+
+```diff
+management_eapi:
++ enabled: true
+  enable_https: true
+```
+
+### A management IP or IPv6 is now required to enable eAPI when `default_mgmt_method: oob`
+
+Before AVD 6.x, it was possible to enable eAPI without setting `mgmt_ip` or `ipv6_mgmt_ip` when the default management method was set to out-of-band (which is the default) `default_mgmt_method: oob` and `management_eapi.vrfs` was not set.
+
+Starting with AVD 6.0.0, enabling eAPI when the default management method is set to `oob` and `management_eapi.vrfs` is not set will raise an error if neither `mgmt_ip` nor `ipv6_mgmt_ip` are defined.
+Below changes should be noted to migrate to AVD 6.0.0 without errors.
+
+```diff
+type: l2leaf
+
+management_eapi:
++ enabled: true # This must be set for management_eapi to take effect.
+  enable_https: true
+
+l2leaf:
+  nodes:
+    - name: management-eapi-host
+      id: 1
++     mgmt_ip: 10.10.10.1/8
+```
+
+### Default management interface changed for cEOS platforms
+
+Starting with AVD 6.0.0, the default management interface for cEOS and cEOSLab platforms has been changed from `Management0` to `Management1`.
+
+This change was made because `Management0` in EOS is handled as a virtual interface used in chassis, which limits the possible configuration on it.
+
+If you need to continue using `Management0` for cEOS platforms, you can override this using `custom_platform_settings`:
+
+```diff
++custom_platform_settings:
++  - platforms:
++      - CEOS
++      - cEOS
++      - ceos
++      - cEOSLab
++    management_interface: Management0
+```
 
 ### Length of `uplink_interfaces`, `uplink_switches` and `uplink_switch_interfaces` has to be same
 
@@ -721,11 +721,11 @@ l3_edge:
 +       lacp_fallback_timeout: 30
 ```
 
-### p2p_links now accepts a minimum and maximum of two entries
+### `core_interfaces.p2p_links` or `l3_edge.p2p_links` list keys now accepts a minimum and maximum of two entries
 
-In AVD 5.0.0, p2p_links list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
+In AVD 5.0.0, `core_interfaces.p2p_links` or `l3_edge.p2p_links` list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
 
-Starting AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
+Starting with AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
 
 ```diff
 # The same applies for core_interfaces
@@ -762,7 +762,7 @@ l3_edge:
 
 In AVD 5.x, `bgp_ecmp` had a default value of 4 except for WAN routers where there was no default value.
 
-Starting AVD 6.0.0, the default value for `bgp_ecmp` has been removed to take advantage of the default value in EOS,
+Starting with AVD 6.0.0, the default value for `bgp_ecmp` has been removed to take advantage of the default value in EOS,
 which will be the maximum supported ECMP routes for the platform.
 Now `bgp_ecmp` must be explicitly defined if required.
 
@@ -776,7 +776,7 @@ To retain the previous behavior, set the value explicitly in your input variable
 
 In AVD 5.x, all BGP AS would get converted to `asplain` format in EOS even when it is given in `asdot` format in eos_designs input, since the option to set AS notation was not available in eos_designs.
 
-Starting AVD 6.0.0, BGP AS notation can be set by defining `bgp_as_notation` to `auto`, `asdot` or `asplain` default value is `auto`.
+Starting with AVD 6.0.0, BGP AS notation can be set by defining `bgp_as_notation` to `auto`, `asdot` or `asplain` default value is `auto`.
 
 When `bgp_as_notation: auto` (default), AVD takes decision based on the device input AS number:
     - If the AS number contains a dot (`.`), all other AS numbers get converted to `asdot` notation.
@@ -820,7 +820,7 @@ In previous versions of AVD, the value of `bgp_update_wait_install` was set to `
 
 In previous versions of AVD, the value of `maximum_routes` for underlay `bgp_peer_groups` was hardcoded to `12000` by default.
 
-Starting AVD 6.0.0, new knobs `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` are introduced for setting maximum_routes, with a default value of `256000`.
+Starting with AVD 6.0.0, new knobs `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` are introduced for setting maximum_routes, with a default value of `256000`.
 
 To retain the previous behavior, `maximum_routes` can be set to `12000` under `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` for the particular peer-group.
 
@@ -838,7 +838,7 @@ bgp_peer_groups:
 
 In AVD 5.x, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would set the value to `router_id` ignoring a potential input typo.
 
-Starting AVD 6.0.0, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would raise a validation error.
+Starting with AVD 6.0.0, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would raise a validation error.
 
 To retain the previous behavior, set the value explicitly in your input variables:
 
@@ -859,9 +859,9 @@ To retain the previous behavior when enabling `evpn_prevent_readvertise_to_serve
 + evpn_prevent_readvertise_to_server_mode: source_peer_asn
 ```
 
-### `vtep_diagnostic` change of default behavior for `loopback_ip_pools`, `loopback_ip_range` and `loopback_ipv6_range` under network services
+### Network services VRFs configuration for `vtep_diagnostic` change of default behavior for `loopback_ip_pools`, `loopback_ip_range` and `loopback_ipv6_range`
 
-In AVD 5.x.x, `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools` under `vtep_diagnostic` under network services.
+In AVD 5.x.x, under network services VRFs configuration for `vtep_diagnostic`; `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools`.
 
 As of AVD 6.0.0, if the POD name defined for a device is matching an entry under `loopback_ip_pools`, this entry will take precedence over `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPV6.
 
@@ -903,10 +903,10 @@ To retain the previous behavior, the following change is required:
 
 In AVD 5.x, the parameter `underlay_ospf_maximum_paths`(maximum number of OSPF next-hops in an ECMP route) had no default value.
 
-Starting AVD 6.0.0, default value of `underlay_ospf_maximum_paths` is set to `128`.
+Starting with AVD 6.0.0, default value of `underlay_ospf_maximum_paths` is set to `128`.
 Since `128` is already the EOS system default, it will neither be rendered in the structured configuration nor the CLI configuration.
 
-### It is not possible anymore to override data from the Underlay OSPF process in `network_services`
+### In network services VRF OSPF configuration it is not possible anymore to override data from the Underlay OSPF process
 
 In AVD 5.x, it was possible to override data from the Underlay OSPF process from `network_services` using the default VRF.
 
@@ -932,11 +932,11 @@ To retain previous behaior, it is necessary to either leverage available variabl
 -          max_lsa: 42
 ```
 
-### `vrfs[].ospf.process_id` and `underlay_ospf_process_id` must have different values for all VRFs other than `default`
+### Network services VRF OSPF configuration `vrfs[].ospf.process_id` and `underlay_ospf_process_id` must have different values for all VRFs other than `default`
 
 In AVD 5.x, it was possible to configure the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` for any VRF, which was leading to potentially overwritten configuration.
 
-Starting AVD 6.0.0, setting the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` is not allowed for any VRF other than `default` vrf.
+Starting with AVD 6.0.0, setting the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` is not allowed for any VRF other than `default` vrf.
 
 An error is raised if any VRF have the same `ospf.process_id` as `underlay_ospf_process_id`.
 
@@ -951,153 +951,6 @@ An error is raised if any VRF have the same `ospf.process_id` as `underlay_ospf_
             enabled: true
 -           process_id: 101
 +           process_id: 102 # cannot use same value as underlay_ospf_process_id
-```
-
-### Change of default behavior for PIM-SM multicast for `core_interfaces.p2p_links` and `l3_edge.p2p_links`
-
-In AVD 5.x.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
-
-- `underlay_multicast: true` at the global level
-- `underlay_multicast: true` **and** `include_in_underlay_protocol: true` at the link or profile level
-
-As of AVD 6.0.0, the global `underlay_mutlicast` is replaced with node setting `underlay_multicast.pim_sm.enabled` or global `underlay_mutlicast_pim_sm`.
-Additionally, the `underlay_multicast` key has been replaced by `multicast_pim_sm` for both `core_interfaces.p2p_links[]` and `l3_edge.p2p_links[]`.
-
-The breaking change in default behavior is for `l3_edge` and `core_interfaces` P2P links. PIM-SM is now automatically configured on links when `include_in_underlay_protocol: true`, provided that PIM-SM is already enabled globally (either through node settings or the global key).
-To retain the previous behavior, the following change is required:
-
-```diff
-- underlay_multicast: true
-# # The next line enables globally
-+ underlay_mutlicast_pim_sm: true
-
- l3leafs:
-   [...]
-   nodes:
-     - name: MULTICAST_LEAF
-+      # Alternatively, PIM-SM can be enabled at the node setting level
-+      underlay_multicast:
-+        pim_sm:
-+          enabled: true
-
- # The same applies for l3_edge
- core_interfaces:
-   p2p_links:
-     - nodes: [MULTICAST_LEAF, MULTICAST_PEER]
-       [...]
-       include_in_underlay_protocol: true
-+      # previously `underlay_multicast` had a default of `false`
-+      multicast_pim_sm: false
-```
-
-!!! tip
-    To avoid editing every single `p2p_links`, it is possible to leverage `p2p_links_profiles`.
-
-### Removed the support  of `wan_use_evpn_node_settings_for_lan` key
-
-In AVD 5.x, the key `wan_use_evpn_node_settings_for_lan` was used as preview to use `overlay_routing_protocol`, `evpn_role` and `vtep` node settings for LAN side on WAN devices
-
-Starting with AVD 6.0.0, this is the only possible behavior and the key has been removed.
-
-### Change in default value of `default_overlay_routing_protocol` for `wan_router` and `wan_rr` node type
-
-In AVD 5.x, the default value of `default_overlay_routing_protocol` was `ibgp`.
-
-Starting with AVD 6.0.0, the default value of  `default_overlay_routing_protocol` has been changed to `none`.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-node_type_keys:
-  - key: "wan_router"
-    type: "wan_router"
-    default_evpn_role: "client"
-    default_wan_role: "client"
-    default_underlay_routing_protocol: "none"
-+   default_overlay_routing_protocol: "ibgp"
-    default_flow_tracker_type: "hardware"
-    vtep: true
-    network_services:
-      l3: true
-  - key: "wan_rr"
-    type: "wan_rr"
-    default_evpn_role: "server"
-    default_wan_role: "server"
-    default_underlay_routing_protocol: "none"
-+   default_overlay_routing_protocol: "ibgp"
-    default_flow_tracker_type: "hardware"
-    vtep: true
-    network_services:
-      l3: true
-```
-
-### Change in default value of `default_evpn_role` for `wan_router` and `wan_rr` node type
-
-In AVD 5.x, the default value of `default_evpn_role` was `client` for the wan_router node type and `server` for the `wan_rr` node type.
-
-Starting with AVD 6.0.0, the default value has been changed to `none` for both `wan_router` and `wan_rr`.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-node_type_keys:
-  - key: "wan_router"
-    type: "wan_router"
-+   default_evpn_role: "client"
-    default_wan_role: "client"
-    default_underlay_routing_protocol: "none"
-    default_overlay_routing_protocol: "ibgp"
-    default_flow_tracker_type: "hardware"
-    vtep: true
-    network_services:
-      l3: true
-  - key: "wan_rr"
-    type: "wan_rr"
-+   default_evpn_role: "server"
-    default_wan_role: "server"
-    default_underlay_routing_protocol: "none"
-    default_overlay_routing_protocol: "ibgp"
-    default_flow_tracker_type: "hardware"
-    vtep: true
-    network_services:
-      l3: true
-```
-
-### `wan_mode: autovpn` renamed `wan_mode: legacy-autovpn`
-
-With AVD version 6.0.0 the valid values for `wan_mode` key have changed. If using the `autovpn` mode in AVD 5.x, the `wan_mode` key needs to be updated to `legacy-autovpn`.
-
-```diff
--  wan_mode: autovpn
-+  wan_mode: legacy-autovpn
-```
-
-### Programming all forwarding paths of ECMP routes in the kernel is now enabled via the CLI for WAN routers
-
-In AVD 5.x, for historical reason, the ECMP route programming was enabled by default using an environment variable for the Agent. Effectively, it meant that the default value of `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` was `true`.
-
-Starting with AVD 6.0.0, The key `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` has been removed.
-A new key `kernel_ecmp_cli` under node_type settings has been introduced to control this behavior with `default: true` i.e. the functionality is now enabled by default via the proper CLI.
-
-To retain the previous behavior, for instance because your device does not support the CLI introduced in EOS 4.33.2F, the following change is required:
-
-```diff
-- wan_use_agent_env_var_for_kernel_software_forwarding_ecmp: true
-+ l3leaf:
-+   nodes:
-+    - name: kernel-ecmp-cli-node1
-+      kernel_ecmp_cli: false
-```
-
-### Changes in validation requirements for CV Pathfinder WAN routers
-
-In AVD 5.x.x, WAN routers operating in `cv_pathfinder` mode could be configured without defining `wan_route_servers`, which could result in incomplete or invalid configurations.
-
-Starting AVD 6.0.0, `wan_route_servers` must be configured for WAN routers operating in `cv_pathfinder` mode. If `wan_route_servers` is not defined, AVD will raise a validation error, as this configuration is required for proper CV Pathfinder operation.
-
-```diff
-+ wan_route_servers:
-+  - hostname: uplink_lan_wan_router1
 ```
 
 ### New 802.1X configuration model
@@ -1177,11 +1030,158 @@ aaa_settings:
 +   # redistribute_in_evpn: true
 ```
 
+### Change of the default behavior for PIM-SM multicast for `core_interfaces.p2p_links` and `l3_edge.p2p_links`
+
+In AVD 5.x.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
+
+- `underlay_multicast: true` at the global level
+- `underlay_multicast: true` **and** `include_in_underlay_protocol: true` at the link or profile level
+
+As of AVD 6.0.0, the global `underlay_mutlicast` is replaced with node setting `underlay_multicast.pim_sm.enabled` or global `underlay_mutlicast_pim_sm`.
+Additionally, the `underlay_multicast` key has been replaced by `multicast_pim_sm` for both `core_interfaces.p2p_links[]` and `l3_edge.p2p_links[]`.
+
+The breaking change in default behavior is for `l3_edge` and `core_interfaces` P2P links. PIM-SM is now automatically configured on links when `include_in_underlay_protocol: true`, provided that PIM-SM is already enabled globally (either through node settings or the global key).
+To retain the previous behavior, the following change is required:
+
+```diff
+- underlay_multicast: true
+# # The next line enables globally
++ underlay_mutlicast_pim_sm: true
+
+ l3leafs:
+   [...]
+   nodes:
+     - name: MULTICAST_LEAF
++      # Alternatively, PIM-SM can be enabled at the node setting level
++      underlay_multicast:
++        pim_sm:
++          enabled: true
+
+ # The same applies for l3_edge
+ core_interfaces:
+   p2p_links:
+     - nodes: [MULTICAST_LEAF, MULTICAST_PEER]
+       [...]
+       include_in_underlay_protocol: true
++      # previously `underlay_multicast` had a default of `false`
++      multicast_pim_sm: false
+```
+
+!!! tip
+    To avoid editing every single `p2p_links`, it is possible to leverage `p2p_links_profiles`.
+
+### Removed the support  of `wan_use_evpn_node_settings_for_lan` key
+
+In AVD 5.x, the key `wan_use_evpn_node_settings_for_lan` was used as preview to use `overlay_routing_protocol`, `evpn_role` and `vtep` node settings for LAN side on WAN devices
+
+Starting with AVD 6.0.0, this is the only possible behavior and the key has been removed.
+
+### Change in the default value of `default_overlay_routing_protocol` for `wan_router` and `wan_rr` node type
+
+In AVD 5.x, the default value of `default_overlay_routing_protocol` was `ibgp`.
+
+Starting with AVD 6.0.0, the default value of  `default_overlay_routing_protocol` has been changed to `none`.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+node_type_keys:
+  - key: "wan_router"
+    type: "wan_router"
+    default_evpn_role: "client"
+    default_wan_role: "client"
+    default_underlay_routing_protocol: "none"
++   default_overlay_routing_protocol: "ibgp"
+    default_flow_tracker_type: "hardware"
+    vtep: true
+    network_services:
+      l3: true
+  - key: "wan_rr"
+    type: "wan_rr"
+    default_evpn_role: "server"
+    default_wan_role: "server"
+    default_underlay_routing_protocol: "none"
++   default_overlay_routing_protocol: "ibgp"
+    default_flow_tracker_type: "hardware"
+    vtep: true
+    network_services:
+      l3: true
+```
+
+### The default value of `default_evpn_role` for `wan_router` and `wan_rr` node type is now `none`
+
+In AVD 5.x, the default value of `default_evpn_role` was `client` for the wan_router node type and `server` for the `wan_rr` node type.
+
+Starting with AVD 6.0.0, the default value has been changed to `none` for both `wan_router` and `wan_rr`.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+node_type_keys:
+  - key: "wan_router"
+    type: "wan_router"
++   default_evpn_role: "client"
+    default_wan_role: "client"
+    default_underlay_routing_protocol: "none"
+    default_overlay_routing_protocol: "ibgp"
+    default_flow_tracker_type: "hardware"
+    vtep: true
+    network_services:
+      l3: true
+  - key: "wan_rr"
+    type: "wan_rr"
++   default_evpn_role: "server"
+    default_wan_role: "server"
+    default_underlay_routing_protocol: "none"
+    default_overlay_routing_protocol: "ibgp"
+    default_flow_tracker_type: "hardware"
+    vtep: true
+    network_services:
+      l3: true
+```
+
+### The `wan_mode: autovpn` renamed `wan_mode: legacy-autovpn`
+
+With AVD version 6.0.0 the valid values for `wan_mode` key have changed. If using the `autovpn` mode in AVD 5.x, the `wan_mode` key needs to be updated to `legacy-autovpn`.
+
+```diff
+-  wan_mode: autovpn
++  wan_mode: legacy-autovpn
+```
+
+### Programming all forwarding paths of ECMP routes in the kernel is now enabled via the CLI for WAN routers
+
+In AVD 5.x, for historical reason, the ECMP route programming was enabled by default using an environment variable for the Agent. Effectively, it meant that the default value of `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` was `true`.
+
+Starting with AVD 6.0.0, The key `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` has been removed.
+A new key `kernel_ecmp_cli` under node_type settings has been introduced to control this behavior with `default: true` i.e. the functionality is now enabled by default via the proper CLI.
+
+To retain the previous behavior, for instance because your device does not support the CLI introduced in EOS 4.33.2F, the following change is required:
+
+```diff
+- wan_use_agent_env_var_for_kernel_software_forwarding_ecmp: true
++ l3leaf:
++   nodes:
++    - name: kernel-ecmp-cli-node1
++      kernel_ecmp_cli: false
+```
+
+### Changes in validation requirements for CV Pathfinder WAN routers
+
+In AVD 5.x.x, WAN routers operating in `cv_pathfinder` mode could be configured without defining `wan_route_servers`, which could result in incomplete or invalid configurations.
+
+Starting with AVD 6.0.0, `wan_route_servers` must be configured for WAN routers operating in `cv_pathfinder` mode. If `wan_route_servers` is not defined, AVD will raise a validation error, as this configuration is required for proper CV Pathfinder operation.
+
+```diff
++ wan_route_servers:
++  - hostname: uplink_lan_wan_router1
+```
+
 ### Custom keys starting without `_` in structured config are no longer supported
 
 In AVD 5.x, custom keys starting with or without `_` were accepted in structured config.
 
-Starting AVD 6.0.0, only custom keys that begin with `_` are accepted in structured config.
+Starting with AVD 6.0.0, only custom keys that begin with `_` are accepted in structured config.
 
 ```diff
 l3leaf:
@@ -1196,7 +1196,7 @@ l3leaf:
 
 ### Removal of default Jinja2 templates for `interface_descriptions` and `ip_addressing` in eos_designs
 
-Starting AVD 6.0.0, the default templates for `interface_descriptions` and `ip_addressing` are removed from the eos_designs role. Custom templates may still be provided, but the role no longer includes built-in templates.
+Starting with AVD 6.0.0, the default templates for `interface_descriptions` and `ip_addressing` are removed from the eos_designs role. Custom templates may still be provided, but the role no longer includes built-in templates.
 
 The removed default templates for ip_addressing are:
 
@@ -1246,7 +1246,7 @@ node_type_keys:
 
 ### Removing support for templating of internal `switch.*` variables in Jinja templates
 
-Starting AVD 6.0.0, Jinja templates will no longer have access to internal AVD variables previously exposed as `switch.*`.
+Starting with AVD 6.0.0, Jinja templates will no longer have access to internal AVD variables previously exposed as `switch.*`.
 This also applies to inline Jinja templates in the input variables (like host vars, group vars, task vars and play vars).
 
 Examples of variables that can no longer be used:
@@ -1266,7 +1266,7 @@ Users with a support agreement can contact Arista support to get assistance.
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
-### Removal of deprecated eos_cli_config_gen data models
+### Removal of deprecated EOS Config (eos_cli_config_gen) data models
 
 The following data model keys have been removed from `eos_cli_config_gen` in AVD 6.0.0.
 
@@ -1389,7 +1389,42 @@ The following data model keys have been removed from `eos_cli_config_gen` in AVD
 
 Starting with AVD 6.0.0, CLI configuration ordering follows EOS 4.35.0F. As a result, the generated configuration files may show ordering differences compared to AVD 5.x.
 
-### Data-models changed to handle VRF entries
+### New EOS Config (eos_cli_config_gen) schema restrictions
+
+Starting with AVD 6.0.0, the following EOS Configdata model keys will have defined restrictions in `eos_cli_config_gen`.
+
+| Keys | Restrictions |
+| ---- | ------------ |
+| `aaa_accounting.commands.console[].type` | required |
+| `aaa_accounting.commands.default[].type` | required |
+| `aaa_accounting.dot1x.default.type` | required |
+| `aaa_accounting.exec.default.type` | required |
+| `aaa_accounting.system.default.type` | required |
+| `dhcp_servers[].ipv4_vendor_options` | `min_length: 1` |
+| `ethernet_interfaces[].ipv6_dhcp_relay_destinations[].address` | required but not unique |
+| `ethernet_interfaces[].link_tracking.direction` | required |
+| `ethernet_interfaces[].link_tracking.groups` | required, `min_length: 1` |
+| `ethernet_interfaces[].link_tracking_groups[].direction` | required |
+| `ethernet_interfaces[].speed` | Added valid_values |
+| `logging.level.severity` | required |
+| `logging.policy.match.match_lists[].action` | required |
+| `management_interfaces[].speed` | Added valid_values |
+| `management_security.ssl_profiles[].name` | primary key |
+| `port_channel_interfaces[].link_tracking.direction` | required |
+| `port_channel_interfaces[].link_tracking.groups` | required, `min_length: 1` |
+| `port_channel_interfaces[].link_tracking_groups[].direction` | required |
+| `port_channel_interfaces[].switchport.port_security.vlans[].mac_address_maximum` | required |
+| `roles[].sequence_numbers[].sequence` | primary |
+| `roles[].sequence_numbers[].action` | required |
+| `roles[].sequence_numbers[].command` | required |
+| `router_adaptive_virtual_topology.vrfs[].profiles[].name` | primary |
+| `router_adaptive_virtual_topology.vrfs[].profiles[].id` | required |
+| `router_general.vrfs[].leak_routes[].source_vrf` | required |
+| `router_isis.segment_routing_mpls.prefix_segments[].prefix` | primary key |
+| `router_isis.set_overload_bit.enabled` | required |
+| `sflow.interface.egress.enable_default` | required |
+
+### EOS Config (eos_cli_config_gen) data-models changed to handle VRF entries
 
 | Old data-model | New data-model |
 | -------------- | -------------- |
@@ -1568,7 +1603,7 @@ radius_server:
 
 In AVD 5.x, the key `dhcp_servers.subnets` was used to define both IPv4 and IPv6 DHCP subnets under a single list.
 
-Starting AVD 6.0.0, this key has been **removed** and replaced with two separate keys for clarity and protocol distinction:
+Starting with AVD 6.0.0, this key has been **removed** and replaced with two separate keys for clarity and protocol distinction:
 
 - `dhcp_servers.ipv4_subnets` for IPv4 DHCP subnets
 - `dhcp_servers.ipv6_subnets` for IPv6 DHCP subnets
@@ -1588,22 +1623,19 @@ Starting AVD 6.0.0, this key has been **removed** and replaced with two separate
 +       default_gateway: 2001:db8::1
 ```
 
-### Traffic policy named counters must now be explicitly defined under `traffic_policies.policies[].counters`
+### `dynamic_prefix_lists[].match_map` is not required anymore
 
-In AVD 5.0.0, named counters were generated automatically based on the `traffic_policies.policies[].matches[].actions[].count` key.
+In AVD 5.x, the value of `dynamic_prefix_lists[].match_map` was implicitly required to configure 'dynamic prefix-list {{ dynamic_prefix_lists[].name }}' command.
 
-Starting AVD 6.0.0, this automatic generation has been removed. All named counters must be defined under the new `traffic_policies.policies[].counters` key.
+In AVD 6.0.0, this command can be configured without setting `dynamic_prefix_lists[].match_map` as shown below.
 
 ```diff
-  traffic_policies:
-    policies:
-      - name: BLUE-C1-POLICY
-+       counters:
-+         - DEMO-TRAFFIC
-        matches:
-          - name: BLUE-C2-POLICY-01
-            actions:
-              count: DEMO-TRAFFIC
+dynamic_prefix_lists:
+  - name: DYNAMIC_PREFIX_LIST_NAME_3
+#   match_map: Test_2
+    prefix_list:
+      ipv4: IPV4_PREFIX_LIST
+      ipv6: IPV6_PREFIX_LIST
 ```
 
 ### `errdisable.recovery.causes` is now a list of dictionaries
@@ -1623,39 +1655,6 @@ errdisable:
 +     - name: tapagg
 ```
 
-### `ntp.servers[].vrf` moved to `ntp.vrf` since all NTP servers must use the same VRF
-
-In AVD 5.x, the VRF for NTP servers was defined individually under `ntp.servers[].vrf`.
-
-Starting with AVD 6.0.0, because in EOS all NTP servers must be in the same VRF, `ntp.servers[].vrf` has been replaced by `ntp.vrf` to avoid misconfigurations.
-
-```diff
-ntp:
-+ vrf: VRF1
-  servers:
-    - name: 2.2.2.55
--     vrf: VRF1
-```
-
-### Updated the IPv6 OSPF data model for VLAN interfaces to support Process ID
-
-In AVD 5.x, IPv6 OSPF area on VLAN interfaces was configured using the key `ipv6_ospf_area`. This structure did not allow the definition of the OSPF Process ID, which could result in incomplete or incorrect EOS commands being generated. Additionally, the interface network type was configured using the standalone key `ipv6_ospf_network_point_to_point`.
-
-Starting with AVD 6.0.0, `ipv6_ospf_area` has been replaced by the dictionary `ipv6_ospf.process.area`. This change allows defining both the Process ID and area explicitly. The interface network type configuration has also been moved under the same dictionary as `network_point_to_point`. These changes ensure the correct EOS command `ipv6 ospf <process-id> area <area-id>` is generated and keep all IPv6 OSPF related settings grouped together.
-
-```diff
-vlan_interfaces:
-  - name: Vlan11
-    ipv6_enable: true
--   ipv6_ospf_network_point_to_point: true
--   ipv6_ospf_area: 0.0.0.0
-+   ipv6_ospf:
-+     process:
-+       id: 100
-+       area: 0.0.0.0
-+     network_point_to_point: true
-```
-
 ### `ip_dhcp_snooping.information_option.enabled` is not a required key
 
 In AVD 5.x, the value of `ip_dhcp_snooping.information_option.enabled` was implicitly required as true to configure 'ip dhcp snooping information option circuit-id type xx format xx' command.
@@ -1670,41 +1669,25 @@ ip_dhcp_snooping:
     circuit_id_option: %p:%v
 ```
 
-### `dynamic_prefix_lists[].match_map` is not required anymore
+### `ntp.servers[].vrf` moved to `ntp.vrf` since all NTP servers must use the same VRF
 
-In AVD 5.x, the value of `dynamic_prefix_lists[].match_map` was implicitly required to configure 'dynamic prefix-list {{ dynamic_prefix_lists[].name }}' command.
+In AVD 5.x, the VRF for NTP servers was defined individually under `ntp.servers[].vrf`.
 
-In AVD 6.0.0, this command can be configured without setting `dynamic_prefix_lists[].match_map` as shown below.
+Starting with AVD 6.0.0, because in EOS all NTP servers must be in the same VRF, `ntp.servers[].vrf` has been replaced by `ntp.vrf` to avoid misconfigurations.
 
 ```diff
-dynamic_prefix_lists:
-  - name: DYNAMIC_PREFIX_LIST_NAME_3
-#   match_map: Test_2
-    prefix_list:
-      ipv4: IPV4_PREFIX_LIST
-      ipv6: IPV6_PREFIX_LIST
+ntp:
++ vrf: VRF1
+  servers:
+    - name: 2.2.2.55
+-     vrf: VRF1
 ```
 
 ### `no-drop` is no longer a valid value for `priority_flow_control.watchdog.action`
 
 In AVD 5.x, the valid values for `priority_flow_control.watchdog.action` were `drop` and `no-drop`.
 
-Starting AVD 6.0.0, `no-drop` has been removed from the valid values for `priority_flow_control.watchdog.action`, as it is not supported by EOS. The valid values are now `drop`, `errdisable`, and `notify-only`.
-
-### `router_isis.set_overload_bit.enabled` is now required to generate the configuration and documentation for `ISIS Overload Bit` configurations
-
-AVD 5.0.0 generated the ISIS set_overload_bit configuration and documentation independently of the `router_isis.set_overload_bit.enabled` key and allowed both `set-overload-bit` (permanent) and `set-overload-bit on-startup` to be rendered simultaneously in the configuration.
-
-As of AVD 6.0.0, `router_isis.set_overload_bit.enabled` must be set to generate the configuration and documentation for `router_isis.set_overload_bit` and `set-overload-bit on-startup` command gets precedence in the configuration.
-
-```diff
- router_isis:
-   set_overload_bit:
-+    enabled: true
-     on_startup:
-       wait_for_bgp:
-         enabled: true
-```
+Starting with AVD 6.0.0, `no-drop` has been removed from the valid values for `priority_flow_control.watchdog.action`, as it is not supported by EOS. The valid values are now `drop`, `errdisable`, and `notify-only`.
 
 ### Changes to the `roles[].sequence_numbers` data model
 
@@ -1724,50 +1707,59 @@ As of AVD 6.0.0, `roles[].sequence_numbers[].sequence`, `roles[].sequence_number
          command: "show interfaces description"
 ```
 
-### New eos_cli_config_gen schema restrictions
+### `router_isis.set_overload_bit.enabled` is now required to generate the configuration and documentation for `ISIS Overload Bit` configurations
 
-Starting AVD 6.0.0, the following data model keys will have defined restrictions in `eos_cli_config_gen`.
+AVD 5.0.0 generated the ISIS set_overload_bit configuration and documentation independently of the `router_isis.set_overload_bit.enabled` key and allowed both `set-overload-bit` (permanent) and `set-overload-bit on-startup` to be rendered simultaneously in the configuration.
 
-| Keys | Restrictions |
-| ---- | ------------ |
-| `aaa_accounting.commands.console[].type` | required |
-| `aaa_accounting.commands.default[].type` | required |
-| `aaa_accounting.dot1x.default.type` | required |
-| `aaa_accounting.exec.default.type` | required |
-| `aaa_accounting.system.default.type` | required |
-| `dhcp_servers[].ipv4_vendor_options` | `min_length: 1` |
-| `ethernet_interfaces[].ipv6_dhcp_relay_destinations[].address` | required but not unique |
-| `ethernet_interfaces[].link_tracking.direction` | required |
-| `ethernet_interfaces[].link_tracking.groups` | required, `min_length: 1` |
-| `ethernet_interfaces[].link_tracking_groups[].direction` | required |
-| `ethernet_interfaces[].speed` | Added valid_values |
-| `logging.level.severity` | required |
-| `logging.policy.match.match_lists[].action` | required |
-| `management_interfaces[].speed` | Added valid_values |
-| `management_security.ssl_profiles[].name` | primary key |
-| `port_channel_interfaces[].link_tracking.direction` | required |
-| `port_channel_interfaces[].link_tracking.groups` | required, `min_length: 1` |
-| `port_channel_interfaces[].link_tracking_groups[].direction` | required |
-| `port_channel_interfaces[].switchport.port_security.vlans[].mac_address_maximum` | required |
-| `roles[].sequence_numbers[].sequence` | primary |
-| `roles[].sequence_numbers[].action` | required |
-| `roles[].sequence_numbers[].command` | required |
-| `router_adaptive_virtual_topology.vrfs[].profiles[].name` | primary |
-| `router_adaptive_virtual_topology.vrfs[].profiles[].id` | required |
-| `router_general.vrfs[].leak_routes[].source_vrf` | required |
-| `router_isis.segment_routing_mpls.prefix_segments[].prefix` | primary key |
-| `router_isis.set_overload_bit.enabled` | required |
-| `sflow.interface.egress.enable_default` | required |
-
-## Changes to role `arista.avd.anta_runner`
-
-### The role variable `anta_report_hide_statuses` has been renamed to `anta_report_exclude_statuses` for clarity
+As of AVD 6.0.0, `router_isis.set_overload_bit.enabled` must be set to generate the configuration and documentation for `router_isis.set_overload_bit` and `set-overload-bit on-startup` command gets precedence in the configuration.
 
 ```diff
-vars:
--  anta_report_hide_statuses: [ "success" ]
-+  anta_report_exclude_statuses: [ "success" ]
+ router_isis:
+   set_overload_bit:
++    enabled: true
+     on_startup:
+       wait_for_bgp:
+         enabled: true
 ```
+
+### Traffic policy named counters must now be explicitly defined under `traffic_policies.policies[].counters`
+
+In AVD 5.0.0, named counters were generated automatically based on the `traffic_policies.policies[].matches[].actions[].count` key.
+
+Starting with AVD 6.0.0, this automatic generation has been removed. All named counters must be defined under the new `traffic_policies.policies[].counters` key.
+
+```diff
+  traffic_policies:
+    policies:
+      - name: BLUE-C1-POLICY
++       counters:
++         - DEMO-TRAFFIC
+        matches:
+          - name: BLUE-C2-POLICY-01
+            actions:
+              count: DEMO-TRAFFIC
+```
+
+### Updated the IPv6 OSPF data model for `vlan_interfaces` to support Process ID
+
+In AVD 5.x, IPv6 OSPF area on VLAN interfaces was configured using the key `ipv6_ospf_area`. This structure did not allow the definition of the OSPF Process ID, which could result in incomplete or incorrect EOS commands being generated. Additionally, the interface network type was configured using the standalone key `ipv6_ospf_network_point_to_point`.
+
+Starting with AVD 6.0.0, `ipv6_ospf_area` has been replaced by the dictionary `ipv6_ospf.process.area`. This change allows defining both the Process ID and area explicitly. The interface network type configuration has also been moved under the same dictionary as `network_point_to_point`. These changes ensure the correct EOS command `ipv6 ospf <process-id> area <area-id>` is generated and keep all IPv6 OSPF related settings grouped together.
+
+```diff
+vlan_interfaces:
+  - name: Vlan11
+    ipv6_enable: true
+-   ipv6_ospf_network_point_to_point: true
+-   ipv6_ospf_area: 0.0.0.0
++   ipv6_ospf:
++     process:
++       id: 100
++       area: 0.0.0.0
++     network_point_to_point: true
+```
+
+## Changes to Ansible role `arista.avd.anta_runner`
 
 ### The role variable `avd_catalogs_allow_bgp_vrfs` has been removed
 
@@ -1798,6 +1790,14 @@ tenants:
         vrf_vni: 10
         # This will validate configured BGP peers in VRF10.
 +       validate_bgp_peers: true
+```
+
+### The role variable `anta_report_hide_statuses` has been renamed to `anta_report_exclude_statuses` for clarity
+
+```diff
+vars:
+-  anta_report_hide_statuses: [ "success" ]
++  anta_report_exclude_statuses: [ "success" ]
 ```
 
 ### Execution of user-defined catalogs stored in `user_catalogs_dir` is now disabled by default

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -59,12 +59,6 @@ This is no longer needed as the extensions are automatically loaded in `pyavd` w
 -jinja2_extensions = jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
 ```
 
-### The `anta` Python library is now a core dependency of `pyavd` Python package
-
-In AVD 6.0.0, the `anta` library has been promoted from an optional dependency (previously part of the `ansible-collection` extra) to a core requirement of `pyavd`.
-
-This ensures that ANTA-related PyAVD functions are available immediately upon installation without requiring additional extras or manual package installation.
-
 ## Removal of Ansible components
 
 The following Ansible components have been removed from the `arista.avd` Ansible collection in version 6.0.0.

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -71,7 +71,6 @@ The following Ansible components have been removed from the `arista.avd` Ansible
 
 | Component type | Name | Replacement |
 | -------------- | ---- | ----------- |
-| Filter | `arista.avd.xxx` | |
 | Action plugin/Module | `arista.avd.configlet_build_config` | The internal `arista.avd.configlet_build_config` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
 | Action plugin/Module | `arista.avd.inventory_to_container` | The internal `arista.avd.inventory_to_container` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
 | Role | `arista.avd.dhcp_provisioner` | The role is not compatible with modern DHCP servers and should not be used for production. The `arista.avd.dhcp_provisioner` role is released as open source, so it can be copied and reused according to the license and copyright. |
@@ -79,9 +78,7 @@ The following Ansible components have been removed from the `arista.avd` Ansible
 | Role | `arista.avd.cvp_configlet_upload` | Migrate to `arista.avd.cv_deploy`. See the [detailed porting guide](../howto/migrate-to-cv-deploy.md) for instructions. |
 | Role | `arista.avd.eos_validate_state` | Migrate to `arista.avd.anta_runner`. See the [how-to guide](../howto/migrate-to-anta-runner.md) for instructions. |
 
-## Changes to Ansible components
-
-### `sort_key` is now mandatory when sorting list of dictionaries using `arista.avd.natural_sort`
+## Changes to Ansible filter plugin arista.avd.natural_sort
 
 In AVD 6.0.0, `sort_key` is now mandatory when sorting list of dictionaries using `arista.avd.natural_sort`. Previously, `sort_key` was not required and when omitted, the key used to sort
 was the output of `str` on each items. This could lead to inconsistent behavior when the items do not have keys in the same order in the dictionary.
@@ -95,7 +92,7 @@ was the output of `str` on each items. This could lead to inconsistent behavior 
  {%                     set collector_cli =  collector_cli ~ " port " ~ collector.port %}
 ```
 
-## Changes to role arista.avd.eos_designs
+## Changes to Ansible role arista.avd.eos_designs
 
 ### Removal of deprecated eos_designs data models
 
@@ -164,6 +161,57 @@ The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
 | `underlay_mutlticast` | `underlay_mutlticast_pim_sm` or `<node_type_key>.defaults.underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].nodes[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.nodes[].underlay_multicast.pim_sm.enabled` |
 | `underlay_ospf_authentication.message_digest_keys[].key` | `underlay_ospf_authentication.message_digest_keys[].cleartext_key` |
 
+
+### New eos_designs schema restrictions
+
+Starting AVD 6.0.0, the following data model keys will have defined restrictions in `eos_designs`.
+
+| Keys | New Restrictions |
+| ---- | ---------------- |
+| `aaa_settings.accounting.commands.console[].type` | required |
+| `aaa_settings.accounting.commands.default[].type` | required |
+| `aaa_settings.accounting.exec.default.type` | required |
+| `aaa_settings.accounting.system.default.type` | required |
+| `default_interfaces[].mlag_interfaces_speed` | Added valid_values |
+| `default_interfaces[].uplink_interface_speed` | Added valid_values |
+| `<custom_connected_endpoints_keys.key>[].adapters[].speed` | Added valid_values |
+| `network_ports[].switches` | min_length: 1 |
+| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].address_family` | required |
+| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].route_target` | required |
+| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].type` | required |
+| `<network_services_keys.name>[].vrfs[].l3_interfaces[].ospf.message_digest_keys[].id` | Primary key |
+| `<network_services_keys.name>[].vrfs[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
+| `<network_services_keys.name>[].vrfs[].l3_port_channels[].ospf.message_digest_keys[].id` | Primary key |
+| `<network_services_keys.name>[].vrfs[].svis[].ospf.message_digest_keys[].id` | Primary key |
+| `<network_services_keys.name>[].vrfs[].svis[].nodes[].ospf.message_digest_keys[].id` | Primary key |
+| `<node_type_keys.key>.defaults.uplink_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].nodes[].uplink_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].uplink_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.nodes[].uplink_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.defaults.uplink_switch_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].nodes[].uplink_switch_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].uplink_switch_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.nodes[].uplink_switch_interface_speed` | Added valid_values |
+| `<node_type_keys.key>.defaults.mlag_interfaces_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].nodes[].mlag_interfaces_speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].mlag_interfaces_speed` | Added valid_values |
+| `<node_type_keys.key>.nodes[].mlag_interfaces_speed` | Added valid_values |
+| `<node_type_keys.key>.defaults.l3_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].nodes[].l3_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].l3_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.nodes[].l3_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.defaults.l3_port_channels[].member_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].nodes[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.node_groups[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
+| `<node_type_keys.key>.nodes[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
+| `p2p_links[].description` | min_length: 2, max_length: 2 |
+| `p2p_links[].interfaces` | min_length: 2, max_length: 2 |
+| `p2p_links[].ip` | min_length: 2, max_length: 2 |
+| `p2p_links[].nodes` | min_length: 2, max_length: 2 |
+| `p2p_links[].speed` | Added valid_values |
+| `svi_profiles[].ospf.message_digest_keys[].id` | Primary key |
+| `svi_profiles[].nodes[].ospf.message_digest_keys[].id` | Primary key |
+
 ### Removal of `avd_eos_designs_unset_facts`
 
 In previous versions of AVD, `avd_eos_designs_unset_facts` was used to unset `avd_switch_facts` from Ansible facts after the `eos_designs` role completed.
@@ -214,7 +262,7 @@ To retain access to these files, set `eos_designs_keep_tmp_files: true`. This pr
 
     Please refer to the [Ansible Vault documentation](https://docs.ansible.com/projects/ansible/latest/vault_guide/index.html) for more details.
 
-<!-- The title below is used in an error message in the AVD collection, please do not edit! -->
+<!-- This title is used in an error message in the AVD collection, please do not edit! -->
 ### Using EOS Config inputs (`eos_cli_config_gen`) keys when running `eos_designs`
 
 For several AVD major versions, it has been possible to use variables from the EOS Config (`eos_cli_config_gen`) data model in conjunction with variables from the AVD Design (`eos_designs`) data model.
@@ -223,7 +271,7 @@ When the `eos_designs` role runs, the EOS Config (`eos_cli_config_gen`) keys wer
 While this behavior could serve as a good escape hatch, it has led to confusion among users. Especially when new features introduced in `eos_designs` role ended up shadowing the EOS Config inputs intended for `eos_cli_config_gen`,
 sometimes leading to configuration changes after a minor releases upgrade.
 
-Starting with AVD 6.0, the `eos_designs` role emits warnings identifying the native EOS Config input keys being used at the top level of AVD Design input data.
+Starting with AVD 6.0.0, the `eos_designs` role emits warnings identifying the native EOS Config input keys being used at the top level of AVD Design input data.
 These keys are ignored during `eos_cli_config_gen` processing when the role is used after `eos_designs` role (except when `read_structured_config_from_file: false` is set when running `eos_cli_config_gen`).
 
 The solutions to address such warning should be in order of priority:
@@ -233,27 +281,25 @@ The solutions to address such warning should be in order of priority:
 
 #### Example
 
-The following EOS Config key:
+The following EOS Config key will emit a warning when read by `eos_designs` and no configuration is rendered:
 
 ```yaml
 # This will warn
 dns_domain: my.awesome.domain.local
 ```
 
-emits a warning when read by `eos_designs` and no configuration is rendered.
-
-Following solution 1, it should be changed to
+Solution 1, leverage an available an eos_designs data model if applicable:
 
 ```yaml
 dns_settings:
   domain: my.awesome.domain.local
 ```
 
-Following the less preferred option 2, it could have been changed to:
+Solution 2 (less desirable), leverage [custom_structured_configuration](../../ansible_collections/arista/avd/roles/eos_designs/docs/how-to/custom-structured-configuration.md):
 
 ```yaml
 ---
-# assuming a default custom structured configuration prefix
+# Assuming the default custom structured configuration prefix
 # this will not warn
 custom_structured_configuration_dns_domain: my.awesome.domain.local
 ```
@@ -287,7 +333,7 @@ eos_designs_validation_configuration:
 
 ### Enhanced conflict detection in `eos_designs`
 
-In AVD 5.x, conflict detection was done per data model (e.g., `network_services`, `connected_endpoints`, ...).
+In AVD 5.x, conflict detection was done per data model (e.g., `network_services`, `connected_endpoints`, etc.).
 This implies that it was possible to declare conflicting information between data models (e.g., overwriting an MLAG interface in `connected_endpoints`), which could lead to difficult-to-track errors.
 
 An optional preview setting, `avd_eos_designs_enforce_duplication_checks_across_all_models`, was introduced in later 5.x releases to enable stricter conflict detection across data models.
@@ -333,13 +379,262 @@ l3_edge:
       include_in_underlay_protocol: false
 ```
 
-But in AVD 6.0.0, it will raise this issue:
+In AVD 6.0.0, this will raise an error:
 
 ```shell
 fatal: [mlag-leaf-1 -> localhost]: FAILED! => {"changed": false, "msg": "Found duplicate objects with conflicting data while generating configuration for EthernetInterfaces.
 {'name': 'Ethernet3', 'description': 'L3_EDGE_peer_Ethernet1', 'shutdown': False, 'mtu': 9214, 'metadata': {'peer': 'peer', 'peer_interface': 'Ethernet1', 'peer_type': 'other'},
 'switchport': {'enabled': False}} conflicts with {'name': 'Ethernet3', 'description': 'MLAG_PEER_mlag-leaf-2_Ethernet3', 'shutdown': False, 'channel_group': {'id': 3, 'mode': 'active'},
 'metadata': {'peer': 'mlag-leaf-2', 'peer_interface': 'Ethernet3', 'peer_type': 'mlag_peer'}}."}
+```
+
+### Removal of design.type
+
+In AVD 5.x, the variable `design.type` was used to select between different variants of default values for `node_type_keys`.
+
+As of AVD 6.x, the `design.type` variable has been removed. The default values of `node_type_keys` combine all the default node type from all designs.
+
+```diff
+# Remove the design.type setting
+- design:
+-   type: l2ls
+```
+
+### Change in data model for DNS name servers `name_servers`
+
+In AVD 5.x, DNS name servers were configured using the top-level key `name_servers`.
+
+Starting with AVD 6.0.0, the `name_servers` data model has been replaced by `dns_settings.servers`, which uses a structured format to define DNS server IP addresses.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+- name_servers:
+-   - 192.168.200.5
+-   - 8.8.8.8
++ dns_settings:
++   servers:
++     - ip_address: 192.168.200.5
++     - ip_address: 8.8.8.8
+```
+
+### The default value for `snmp_settings.compute_local_engineid_source` is now `rfc3411_type5`
+
+In AVD 5.x, the default value of `snmp_settings.compute_local_engineid_source` was `hostname_and_ip`. This method has several issues;
+firstly the method is not using the inband management IP, even if no management interface IP is set, and secondly the resulting Engine ID is not compliant with the RFC3411 format.
+
+Starting with AVD 6.0.0, the default value has been changed to `rfc3411_type5`. This now generates a RFC3411 Type 5 compliant engine ID and handles the inband management IP cases properly.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+snmp_settings:
++  compute_local_engineid_source: hostname_and_ip
+```
+
+### Change in SNMP data model from `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf` to `snmp_settings.vrfs[]`
+
+In AVD 5.x, SNMP could be enabled on special management VRFs using `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf`.
+
+Starting with AVD 6.0.0, these keys have been removed. SNMP VRFs must now be explicitly defined under `snmp_settings.vrfs` with the proper name and enable field.
+
+To retain the previous behavior, the following change is required:
+
+```diff
+snmp_settings:
+- enable_inband_mgmt_vrf: true
+- enable_mgmt_interface_vrf: true
++ vrfs:
++   - name: use_inband_mgmt_vrf
++     enable: true
++   - name: use_mgmt_interface_vrf
++     enable: true
+```
+
+### SNMP `snmp-server` IPv4 and IPv6 ACLs are now only configured when the VRF is enabled under `snmp_settings.vrfs`
+
+In AVD 5.x, SNMP `snmp-server` IPv4 and IPv6 ACLs were rendered even when the VRF was not enabled under `snmp_settings.vrfs`.
+
+Starting AVD 6.0.0, it is required to set `enable: true` under the VRF in order to render IPV4 and IPV6 ACLs or use `custom_structured_config`.
+
+```diff
+snmp_settings:
+   vrfs:
+    - name: Test_VRF
++     enable: true
+      ipv4_acl: IPV4
+```
+
+### Changes in local user structured configuration for `no_password` and `disabled`
+
+In AVD 5.x.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
+
+Starting AVD 6.0.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
+
+### eAPI is not enabled by default anymore in eos_designs
+
+In previous versions, `management_eapi.enabled` was `true` by default.
+
+In AVD 6.0.0, this is not the case anymore and eAPI needs to be explicitly enabled as follows:
+
+```diff
+management_eapi:
++ enabled: true
+  enable_https: true
+```
+
+### A management IP or IPv6 is now required to enable eAPI when `default_mgmt_method: oob`
+
+Before AVD 6.x, it was possible to enable eAPI without setting `mgmt_ip` or `ipv6_mgmt_ip` when the default management method was set to out-of-band (which is the default) `default_mgmt_method: oob` and `management_eapi.vrfs` was not set.
+
+Starting AVD 6.0.0, enabling eAPI when the default management method is set to `oob` and `management_eapi.vrfs` is not set will raise an error if neither `mgmt_ip` nor `ipv6_mgmt_ip` are defined.
+Below changes should be noted to migrate to AVD 6.0.0 without errors.
+
+```diff
+type: l2leaf
+
+management_eapi:
++ enabled: true # This must be set for management_eapi to take effect.
+  enable_https: true
+
+l2leaf:
+  nodes:
+    - name: management-eapi-host
+      id: 1
++     mgmt_ip: 10.10.10.1/8
+```
+
+### Default management interface changed for cEOS platforms
+
+Starting AVD 6.0.0, the default management interface for cEOS and cEOSLab platforms has been changed from `Management0` to `Management1`.
+
+This change was made because `Management0` in EOS is handled as a virtual interface used in chassis, which limits the possible configuration on it.
+
+If you need to continue using `Management0` for cEOS platforms, you can override this using `custom_platform_settings`:
+
+```diff
++custom_platform_settings:
++  - platforms:
++      - CEOS
++      - cEOS
++      - ceos
++      - cEOSLab
++    management_interface: Management0
+```
+
+### Migrating from CloudVision keys to `cv_settings`
+
+In the previous versions of AVD, you may have defined your CloudVision settings as follows.
+
+=== "Previous Variables"
+
+    ```yaml
+    cvp_instance_ips:
+      - 192.168.200.12
+      - 192.168.200.13
+    cvp_token_file: /tmp/token
+    terminattr_disable_aaa: true
+    terminattr_ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    terminattr_ingestgrpcurl_port: 9910
+    terminattr_smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+    ```
+
+=== "Rendered Configuration"
+
+    ```eos
+    daemon TerminAttr
+      exec /usr/bin/TerminAttr -cvaddr=192.168.200.12:9910,192.168.200.13:9910 -cvauth=token,/tmp/token -cvvrf=default -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+      no shutdown
+    ```
+
+These keys are now removed and replaced with `cv_settings`, to build a similar output, you should update your variables with the following structure.
+
+=== "AVD 6.x"
+
+    ```yaml
+    cv_settings:
+      onprem_clusters:
+        - name: MAIN
+          servers:
+            - name: 192.168.200.12
+            - name: 192.168.200.13
+      terminattr:
+        disable_aaa: true
+        ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+        smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+    ```
+
+=== "Rendered Configuration"
+
+    ```eos
+    daemon TerminAttr
+      exec /usr/bin/TerminAttr -cvaddr=192.168.200.12:9910,192.168.200.13:9910 -cvauth=token,/tmp/token -cvvrf=default -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs -cvsourceintf=Management0 -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+      no shutdown
+    ```
+
+!!! note
+    The example above leverages the built-in defaults, if you would like to override any settings, please refer to the "New key" listed in the [removal of deprecated eos_designs data-models table](#removal-of-deprecated-eos_designs-data-models).
+
+### Changes in validation requirements for CloudVision clusters
+
+In AVD 5.x.x, CloudVision clusters could be configured without enforcing the presence of NTP or DNS settings, even when servers were defined using DNS names.
+
+Starting AVD 6.0.0, additional validation is enforced when CloudVision clusters (on-prem or CVaaS) are configured:
+
+- `ntp_settings.servers` must be configured whenever any CloudVision cluster `cv_settings.cvaas.clusters[]` or `cv_settings.onprem_clusters[].servers[]` are defined.
+- `dns_settings.servers` must be configured when CVaaS clusters `cv_settings.cvaas.clusters[]` are defined.
+- `dns_settings.servers` must be configured for on-prem clusters if any server under `cv_settings.onprem_clusters[].servers[].name` is specified using a DNS name.
+
+These validations ensure that required infrastructure dependencies are explicitly configured when deploying CloudVision clusters.
+
+### Changing behavior of cv_topology and use_cv_topology
+
+The behavior of `cv_topology` and `use_cv_topology` has been changed in the following areas:
+
+- `use_cv_topology: true` now requires `cv_topology_levels` to describe the relationships between devices of each node type, instead of relying on `default_interfaces` to infer this.
+- MLAG peer interfaces are now set to all interfaces towards the MLAG peer.
+- `use_cv_topology: true` can no longer be combined with manually setting `uplink_interfaces`, `uplink_switches`, `uplink_switch_interfaces` or `mlag_interfaces`.
+
+```diff
+use_cv_topology: true
++cv_topology_levels:
++  - type: super-spine
++    level: 1
++  - type: spine
++    level: 2
++  - type: l3leaf
++    level: 3
++  - type: l2leaf
++    level: 4
++  - type: overlay-controller
++    level: 5
+-default_interfaces:
+-  <...>
+cv_topology:
+  <...>
+```
+
+See the [documentation](../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#cloudvision-topology-settings) for `cv_topology` for details on the new behavior.
+
+### Length of `uplink_interfaces`, `uplink_switches` and `uplink_switch_interfaces` has to be same
+
+In AVD 5.x, mismatched lengths for `uplink_interfaces`, `uplink_switches`, and `uplink_switch_interfaces` do not trigger an error. Instead, AVD silently defaults to the minimum length of the three lists, effectively ignoring any trailing entries in the longer lists during configuration generation.
+
+Starting with AVD 6.0.0, the number of entries in `uplink_interfaces` and `uplink_switch_interfaces` must match the number of entries in `uplink_switches`. If this requirement is not met, AVD will raise an appropriate error.
+
+If an error is generated after upgrading, you may need to adjust your inputs and make sure all three lists have the same size:
+
+```diff
+l3leaf:
+  nodes:
+    - name: Test_device
+      id: 1
+      mgmt_ip: 172.16.1.15/24
+      uplink_switches: ['uplink-switch-1', 'uplink-switch-1']
+-     uplink_interfaces: ['Ethernet1']
++     uplink_interfaces: ['Ethernet1', 'Ethernet2']
+-     uplink_switch_interfaces: ['Ethernet3']
++     uplink_switch_interfaces: ['Ethernet3', 'Ethernet4']
 ```
 
 ### Removal of `uplink_structured_config` and introduction of uplink type-specific structured config keys
@@ -427,23 +722,277 @@ l3_edge:
 +       lacp_fallback_timeout: 30
 ```
 
-### Change in data model for DNS name servers `name_servers`
+### p2p_links now accepts a minimum and maximum of two entries
 
-In AVD 5.x, DNS name servers were configured using the top-level key `name_servers`.
+In AVD 5.0.0, p2p_links list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
 
-Starting with AVD 6.0.0, the `name_servers` data model has been replaced by `dns_settings.servers`, which uses a structured format to define DNS server IP addresses.
+Starting AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
+
+```diff
+# The same applies for core_interfaces
+l3_edge:
+  p2p_links:
+-   - ip: [10.10.10.0/31, 10.10.10.1/31, 10.10.10.2/31, 10.10.10.3/31]
+-     nodes: [peer1, peer2, peer3, peer4]
+-     interfaces: [Ethernet1, Ethernet1, Ethernet1, Ethernet1]
+-     descriptions: ["Custom description peer1", "Custom description peer2", "Custom description peer3",  "Custom description peer4"]
++   - ip: [10.10.10.0/31, 10.10.10.1/31]
++     nodes: [peer1, peer2]
++     interfaces: [Ethernet1, Ethernet1]
++     descriptions: ["Custom description peer1", "Custom description peer2"]
++   - ip: [10.10.10.2/31, 10.10.10.3/31]
++     nodes: [peer3, peer4]
++     interfaces: [Ethernet1, Ethernet1]
++     descriptions: ["Custom description peer3", "Custom description peer4"]
+  p2p_links_profiles:
+-   - ip: [10.10.10.0/31, 10.10.10.1/31, 10.10.10.2/31, 10.10.10.3/31]
+-     nodes: [peer1, peer2, peer3, peer4]
+-     interfaces: [Ethernet1, Ethernet1, Ethernet1, Ethernet1]
+-     descriptions: ["Custom description peer1", "Custom description peer2", "Custom description peer3", "Custom description peer4"]
++   - ip: [10.10.10.0/31, 10.10.10.1/31]
++     nodes: [peer1, peer2]
++     interfaces: [Ethernet1, Ethernet1]
++     descriptions: ["Custom description peer1", "Custom description peer2"]
++   - ip: [10.10.10.2/31, 10.10.10.3/31]
++     nodes: [peer3, peer4]
++     interfaces: [Ethernet1, Ethernet1]
++     descriptions: ["Custom description peer3", "Custom description peer4"]
+```
+
+### Removal of default `bgp_ecmp` value
+
+In AVD 5.x, `bgp_ecmp` had a default value of 4 except for WAN routers where there was no default value.
+
+Starting AVD 6.0.0, the default value for `bgp_ecmp` has been removed to take advantage of the default value in EOS,
+which will be the maximum supported ECMP routes for the platform.
+Now `bgp_ecmp` must be explicitly defined if required.
+
+To retain the previous behavior, set the value explicitly in your input variables:
+
+```diff
++ bgp_ecmp: 4
+```
+
+### Configure BGP AS notation to `asdot` or `asplain` using `bgp_as_notation`
+
+In AVD 5.x, all BGP AS would get converted to `asplain` format in EOS even when it is given in `asdot` format in eos_designs input, since the option to set AS notation was not available in eos_designs.
+
+Starting AVD 6.0.0, BGP AS notation can be set by defining `bgp_as_notation` to `auto`, `asdot` or `asplain` default value is `auto`.
+
+When `bgp_as_notation: auto` (default), AVD takes decision based on the device input AS number:
+    - If the AS number contains a dot (`.`), all other AS numbers get converted to `asdot` notation.
+    - If the AS number does not contain a dot, all other AS numbers get converted to `asplain` notation.
+
+It may not be possible to retain the old behavior if you had a mix and match of asdot and asplain notation, which was not rendering what EOS would have rendered anyway.
+
+### Removed autoconversion of `bgp_as` from float under node config
+
+In AVD 5.x.x, the `bgp_as` value under node configuration was automatically converted from a float to a string. This could lead to unintended truncation, for example, `65000.100` being interpreted as `65000.1`.
+
+Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
+To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.
+
+This change applies to below instances of bgp_as:
+
+- node_type.defaults
+- node_type.defaults.evpn_gateway.remote_peers
+- node_type.defaults.ipvpn_gateway.remote_peers
+
+```diff
+node_type:
+  defaults:
+-   bgp_as: 65000.100
++   bgp_as: "65000.100"
+    evpn_gateway:
+      remote_peers:
+-       bgp_as: 65000.100
++       bgp_as: "65000.100"
+    ipvpn_gateway:
+      remote_peers:
+-       bgp_as: 65000.100
++       bgp_as: "65000.100"
+```
+
+### Change in default feature support of `bgp_update_wait_install` on DCS-7358X4
+
+In previous versions of AVD, the value of `bgp_update_wait_install` was set to `false` by default. In AVD 6.0.0 this is now set to `true` by default.
+
+### Change in default value of `maximum-routes` for underlay bgp peer groups
+
+In previous versions of AVD, the value of `maximum_routes` for underlay `bgp_peer_groups` was hardcoded to `12000` by default.
+
+Starting AVD 6.0.0, new knobs `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` are introduced for setting maximum_routes, with a default value of `256000`.
+
+To retain the previous behavior, `maximum_routes` can be set to `12000` under `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` for the particular peer-group.
+
+```diff
+bgp_peer_groups:
+  ipv4_underlay_peers:
++   maximum_routes: 12000
+  mlag_ipv4_underlay_peer:
++   maximum_routes: 12000
+  mlag_ipv4_vrfs_peer:
++   maximum_routes: 12000
+```
+
+### Removal of setting `overlay_rd_type.admin_subfield` to `router_id` on invalid IPv4 address entry
+
+In AVD 5.x, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would set the value to `router_id` ignoring a potential input typo.
+
+Starting AVD 6.0.0, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would raise a validation error.
+
+To retain the previous behavior, set the value explicitly in your input variables:
+
+```diff
+overlay_rd_type:
++ admin_subfield: router_id
+```
+
+### Change of default behavior for `evpn_prevent_readvertise_to_server`
+
+In AVD 5.x.x, enabling `evpn_prevent_readvertise_to_server` would configure an outbound route-map towards EVPN route-servers that would filter out BGP updates learned directly from the ASN of the route-server. This approach would not filter out routes learned via any other peer, even if they had the route-server's ASN in the AS-path.
+
+As of AVD 6.0.0, the new key `evpn_prevent_readvertise_to_server_mode` was introduced to control the mode of matching specific routes to be filtered out. The new default mode `as_path_acl` now relies on the route-map with `as-path access-list` to filter out BGP updates with the route-server ASN anywhere in the AS-path.
+
+To retain the previous behavior when enabling `evpn_prevent_readvertise_to_server`, the following change is required:
+
+```diff
++ evpn_prevent_readvertise_to_server_mode: source_peer_asn
+```
+
+### `vtep_diagnostic` change of default behavior for `loopback_ip_pools`, `loopback_ip_range` and `loopback_ipv6_range` under network services
+
+In AVD 5.x.x, `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools` under `vtep_diagnostic` under network services.
+
+As of AVD 6.0.0, if the POD name defined for a device is matching an entry under `loopback_ip_pools`, this entry will take precedence over `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPV6.
+
+To retain the previous behavior remove the pool under `loopback_ip_pools` where `pod` is matching `pod_name`.
+
+```diff
+  pod_name: TENANT_NETWORKS_POD
+  tenants:
+    - name: Tenant_X
+      mac_vrf_vni_base: 11000
+      vrfs:
+        - name: VRF_with_loopback_ip_pools
+          vrf_id: 22
+          vtep_diagnostic:
+            loopback: 200
+            loopback_ip_pools:
+-             - pod: TENANT_NETWORKS_POD
+-               ipv4_pool: 10.101.102.0/24
+-               ipv6_pool: 2001:db8:1::-2001:db8:1:7fff::
+              - pod: OTHER_POD
+                ipv4_pool: 10.101.103.0/24
+            loopback_ip_range: 10.255.1.0/24
+            loopback_ipv6_range: 2001:db8:1::-2001:db8:1:7fff::
+```
+
+### The default value for `underlay_ospf_graceful_restart` is now `true`
+
+In AVD 5.x, the default value of `underlay_ospf_graceful_restart` was `false`.
+
+Starting with AVD 6.0.0, the default value of  `underlay_ospf_graceful_restart` has been changed to `true`.
 
 To retain the previous behavior, the following change is required:
 
 ```diff
-- name_servers:
--   - 192.168.200.5
--   - 8.8.8.8
-+ dns_settings:
-+   servers:
-+     - ip_address: 192.168.200.5
-+     - ip_address: 8.8.8.8
++ underlay_ospf_graceful_restart: false
 ```
+
+### The default value of `underlay_ospf_maximum_paths` is now set to `128`
+
+In AVD 5.x, the parameter `underlay_ospf_maximum_paths`(maximum number of OSPF next-hops in an ECMP route) had no default value.
+
+Starting AVD 6.0.0, default value of `underlay_ospf_maximum_paths` is set to `128`.
+Since `128` is already the EOS system default, it will neither be rendered in the structured configuration nor the CLI configuration.
+
+### It is not possible anymore to override data from the Underlay OSPF process in `network_services`
+
+In AVD 5.x, it was possible to override data from the Underlay OSPF process from `network_services` using the default VRF.
+
+Starting with AVD 6.0.0, it is only possible to add data to the process but not to override values anymore.
+
+To retain previous behaior, it is necessary to either leverage available variables for the underlay or to use custom_structured_configuration.
+
+```diff
+ underlay_routing_protocol: ospf
+ underlay_ospf_process_id: 101
+ underlay_ospf_graceful_restart: false
++underlay_ospf_max_lsa: 42
+
+ tenants:
+   - name: Tenant-A
+     vrfs:
+       - name: default
+         vrf_id: 2
+         ospf:
+           enabled: true
+           process_id: 101
+-          # max_lsa overwrites underlay ospf max_lsa of 12000.
+-          max_lsa: 42
+```
+
+### `vrfs[].ospf.process_id` and `underlay_ospf_process_id` must have different values for all VRFs other than `default`
+
+In AVD 5.x, it was possible to configure the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` for any VRF, which was leading to potentially overwritten configuration.
+
+Starting AVD 6.0.0, setting the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` is not allowed for any VRF other than `default` vrf.
+
+An error is raised if any VRF have the same `ospf.process_id` as `underlay_ospf_process_id`.
+
+```diff
+  underlay_ospf_process_id: 101
+  tenants:
+    - name: Tenant-A
+      vrfs:
+        - name: ospf-vrf
+          vrf_id: 2
+          ospf:
+            enabled: true
+-           process_id: 101
++           process_id: 102 # cannot use same value as underlay_ospf_process_id
+```
+
+### Change of default behavior for PIM-SM multicast for `core_interfaces.p2p_links` and `l3_edge.p2p_links`
+
+In AVD 5.x.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
+
+- `underlay_multicast: true` at the global level
+- `underlay_multicast: true` **and** `include_in_underlay_protocol: true` at the link or profile level
+
+As of AVD 6.0.0, the global `underlay_mutlicast` is replaced with node setting `underlay_multicast.pim_sm.enabled` or global `underlay_mutlicast_pim_sm`.
+Additionally, the `underlay_multicast` key has been replaced by `multicast_pim_sm` for both `core_interfaces.p2p_links[]` and `l3_edge.p2p_links[]`.
+
+The breaking change in default behavior is for `l3_edge` and `core_interfaces` P2P links. PIM-SM is now automatically configured on links when `include_in_underlay_protocol: true`, provided that PIM-SM is already enabled globally (either through node settings or the global key).
+To retain the previous behavior, the following change is required:
+
+```diff
+- underlay_multicast: true
+# # The next line enables globally
++ underlay_mutlicast_pim_sm: true
+
+ l3leafs:
+   [...]
+   nodes:
+     - name: MULTICAST_LEAF
++      # Alternatively, PIM-SM can be enabled at the node setting level
++      underlay_multicast:
++        pim_sm:
++          enabled: true
+
+ # The same applies for l3_edge
+ core_interfaces:
+   p2p_links:
+     - nodes: [MULTICAST_LEAF, MULTICAST_PEER]
+       [...]
+       include_in_underlay_protocol: true
++      # previously `underlay_multicast` had a default of `false`
++      multicast_pim_sm: false
+```
+
+!!! tip
+    To avoid editing every single `p2p_links`, it is possible to leverage `p2p_links_profiles`.
 
 ### Removed the support  of `wan_use_evpn_node_settings_for_lan` key
 
@@ -524,58 +1073,6 @@ With AVD version 6.0.0 the valid values for `wan_mode` key have changed. If usin
 +  wan_mode: legacy-autovpn
 ```
 
-### OSPF Graceful Restart is now enabled by default in the underlay
-
-In AVD 5.x, the default value of `underlay_ospf_graceful_restart` was `false`.
-
-Starting with AVD 6.0.0, the default value of  `underlay_ospf_graceful_restart` has been changed to `true`.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-+ underlay_ospf_graceful_restart: false
-```
-
-### The default value for `snmp_settings.compute_local_engineid_source` is now `rfc3411_type5`
-
-In AVD 5.x, the default value of `snmp_settings.compute_local_engineid_source` was `hostname_and_ip`. This method has several issues;
-firstly the method is not using the inband management IP, even if no management interface IP is set, and secondly the resulting Engine ID is not compliant with the RFC3411 format.
-
-Starting with AVD 6.0.0, the default value has been changed to `rfc3411_type5`. This now generates a RFC3411 Type 5 compliant engine ID and handles the inband management IP cases properly.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-snmp_settings:
-+  compute_local_engineid_source: hostname_and_ip
-```
-
-### It is not possible anymore to override data from the Underlay OSPF process in `network_services`
-
-In AVD 5.x, it was possible to override data from the Underlay OSPF process from `network_services` using the default VRF.
-
-Starting with AVD 6.0.0, it is only possible to add data to the process but not to override values anymore.
-
-To retain previous behaior, it is necessary to either leverage available variables for the underlay or to use custom_structured_configuration.
-
-```diff
- underlay_routing_protocol: ospf
- underlay_ospf_process_id: 101
- underlay_ospf_graceful_restart: false
-+underlay_ospf_max_lsa: 42
-
- tenants:
-   - name: Tenant-A
-     vrfs:
-       - name: default
-         vrf_id: 2
-         ospf:
-           enabled: true
-           process_id: 101
--          # max_lsa overwrites underlay ospf max_lsa of 12000.
--          max_lsa: 42
-```
-
 ### Programming all forwarding paths of ECMP routes in the kernel is now enabled via the CLI for WAN routers
 
 In AVD 5.x, for historical reason, the ECMP route programming was enabled by default using an environment variable for the Agent. Effectively, it meant that the default value of `wan_use_agent_env_var_for_kernel_software_forwarding_ecmp` was `true`.
@@ -593,608 +1090,16 @@ To retain the previous behavior, for instance because your device does not suppo
 +      kernel_ecmp_cli: false
 ```
 
-### Change of default behavior for PIM-SM multicast for `core_interfaces.p2p_links` and `l3_edge.p2p_links`
-
-In AVD 5.x.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
-
-- `underlay_multicast: true` at the global level
-- `underlay_multicast: true` **and** `include_in_underlay_protocol: true` at the link or profile level
-
-As of AVD 6.0.0, the global `underlay_mutlicast` is replaced with node setting `underlay_multicast.pim_sm.enabled` or global `underlay_mutlicast_pim_sm`.
-Additionally, the `underlay_multicast` key has been replaced by `multicast_pim_sm` for both `core_interfaces.p2p_links[]` and `l3_edge.p2p_links[]`.
-
-The breaking change in default behavior is for `l3_edge` and `core_interfaces` P2P links. PIM-SM is now automatically configured on links when `include_in_underlay_protocol: true`, provided that PIM-SM is already enabled globally (either through node settings or the global key).
-To retain the previous behavior, the following change is required:
-
-```diff
-- underlay_multicast: true
-# # The next line enables globally
-+ underlay_mutlicast_pim_sm: true
-
- l3leafs:
-   [...]
-   nodes:
-     - name: MULTICAST_LEAF
-+      # Alternatively, PIM-SM can be enabled at the node setting level
-+      underlay_multicast:
-+        pim_sm:
-+          enabled: true
-
- # The same applies for l3_edge
- core_interfaces:
-   p2p_links:
-     - nodes: [MULTICAST_LEAF, MULTICAST_PEER]
-       [...]
-       include_in_underlay_protocol: true
-+      # previously `underlay_multicast` had a default of `false`
-+      multicast_pim_sm: false
-```
-
-!!! tip
-    To avoid editing every single `p2p_links`, it is possible to leverage `p2p_links_profiles`.
-
-### Change in SNMP data model from `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf` to `snmp_settings.vrfs[]`
-
-In AVD 5.x, SNMP could be enabled on special management VRFs using `snmp_settings.enable_inband_mgmt_vrf` and `snmp_settings.enable_mgmt_interface_vrf`.
-
-Starting with AVD 6.0.0, these keys have been removed. SNMP VRFs must now be explicitly defined under `snmp_settings.vrfs` with the proper name and enable field.
-
-To retain the previous behavior, the following change is required:
-
-```diff
-snmp_settings:
-- enable_inband_mgmt_vrf: true
-- enable_mgmt_interface_vrf: true
-+ vrfs:
-+   - name: use_inband_mgmt_vrf
-+     enable: true
-+   - name: use_mgmt_interface_vrf
-+     enable: true
-```
-
-### SNMP `snmp-server` IPv4 and IPv6 ACLs are now only configured when the VRF is enabled under `snmp_settings.vrfs`
-
-In AVD 5.x, SNMP `snmp-server` IPv4 and IPv6 ACLs were rendered even when the VRF was not enabled under `snmp_settings.vrfs`.
-
-Starting AVD 6.0.0, it is required to set `enable: true` under the VRF in order to render IPV4 and IPV6 ACLs or use `custom_structured_config`.
-
-```diff
-snmp_settings:
-   vrfs:
-    - name: Test_VRF
-+     enable: true
-      ipv4_acl: IPV4
-```
-
-### Length of `uplink_interfaces`, `uplink_switches` and `uplink_switch_interfaces` has to be same
-
-In AVD 5.x, mismatched lengths for `uplink_interfaces`, `uplink_switches`, and `uplink_switch_interfaces` do not trigger an error. Instead, AVD silently defaults to the minimum length of the three lists, effectively ignoring any trailing entries in the longer lists during configuration generation.
-
-Starting with AVD 6.0.0, the number of entries in `uplink_interfaces` and `uplink_switch_interfaces` must match the number of entries in `uplink_switches`. If this requirement is not met, AVD will raise an appropriate error.
-
-If an error is generated after upgrading, you may need to adjust your inputs and make sure all three lists have the same size:
-
-```diff
-l3leaf:
-  nodes:
-    - name: Test_device
-      id: 1
-      mgmt_ip: 172.16.1.15/24
-      uplink_switches: ['uplink-switch-1', 'uplink-switch-1']
--     uplink_interfaces: ['Ethernet1']
-+     uplink_interfaces: ['Ethernet1', 'Ethernet2']
--     uplink_switch_interfaces: ['Ethernet3']
-+     uplink_switch_interfaces: ['Ethernet3', 'Ethernet4']
-```
-
-### Configure BGP AS notation to Asdot/Asplain using `bgp_as_notation`
-
-In AVD 5.x, all BGP AS would get converted to `asplain` format in EOS even when it is given in `asdot` format in eos_designs input, since the option to set AS notation was not available in eos_designs.
-
-Starting AVD 6.0.0, BGP AS notation can be set by defining `bgp_as_notation` to `auto`, `asdot` or `asplain` default value is `auto`.
-
-When `bgp_as_notation: auto` (default), AVD takes decision based on the device input AS number:
-    - If the AS number contains a dot (`.`), all other AS numbers get converted to `asdot` notation.
-    - If the AS number does not contain a dot, all other AS numbers get converted to `asplain` notation.
-
-It may not be possible to retain the old behavior if you had a mix and match of asdot and asplain notation, which was not rendering what EOS would have rendered anyway.
-
-### Default value of `underlay_ospf_maximum_paths` is set to 128
-
-In AVD 5.x, the parameter `underlay_ospf_maximum_paths`(maximum number of OSPF next-hops in an ECMP route) had no default value.
-
-Starting AVD 6.0.0, default value of `underlay_ospf_maximum_paths` is set to `128`.
-Since `128` is already the EOS system default, it will neither be rendered in the structured configuration nor the CLI configuration.
-
-#### Migrating from CloudVision keys to `cv_settings`
-
-In the previous versions of AVD, you may have defined your CloudVision settings as follows.
-
-=== "Previous Variables"
-
-    ```yaml
-    cvp_instance_ips:
-      - 192.168.200.12
-      - 192.168.200.13
-    cvp_token_file: /tmp/token
-    terminattr_disable_aaa: true
-    terminattr_ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
-    terminattr_ingestgrpcurl_port: 9910
-    terminattr_smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
-    ```
-
-=== "Rendered Configuration"
-
-    ```eos
-    daemon TerminAttr
-      exec /usr/bin/TerminAttr -cvaddr=192.168.200.12:9910,192.168.200.13:9910 -cvauth=token,/tmp/token -cvvrf=default -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
-      no shutdown
-    ```
-
-These keys are now removed and replaced with `cv_settings`, to build a similar output, you should update your variables with the following structure.
-
-=== "AVD 6.x"
-
-    ```yaml
-    cv_settings:
-      onprem_clusters:
-        - name: MAIN
-          servers:
-            - name: 192.168.200.12
-            - name: 192.168.200.13
-      terminattr:
-        disable_aaa: true
-        ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
-        smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
-    ```
-
-=== "Rendered Configuration"
-
-    ```eos
-    daemon TerminAttr
-      exec /usr/bin/TerminAttr -cvaddr=192.168.200.12:9910,192.168.200.13:9910 -cvauth=token,/tmp/token -cvvrf=default -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs -cvsourceintf=Management0 -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
-      no shutdown
-    ```
-
-!!! note
-    The example above leverages the built-in defaults, if you would like to override any settings, please refer to the "New key" listed in the table.
-
-### Custom keys starting without `_` in structured config are no longer supported
-
-In AVD 5.x, custom keys starting with or without `_` were accepted in structured config.
-
-Starting AVD 6.0.0, only custom keys that begin with `_` are accepted in structured config.
-
-```diff
-l3leaf:
-  nodes:
-    - name: host1
-      id: 101
-      bgp_as: 101
-      structured_config:
--        custom_key: [ custom_value ]
-+        _custom_key: [ custom_value ]
-```
-
-### `vrfs[].ospf.process_id` and `underlay_ospf_process_id` must have different values for all VRFs other than `default`
-
-In AVD 5.x, it was possible to configure the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` for any VRF, which was leading to potentially overwritten configuration.
-
-Starting AVD 6.0.0, setting the same value for `vrfs[].ospf.process_id` and `underlay_ospf_process_id` is not allowed for any VRF other than `default` vrf.
-
-An error is raised if any VRF have the same `ospf.process_id` as `underlay_ospf_process_id`.
-
-```diff
-  underlay_ospf_process_id: 101
-  tenants:
-    - name: Tenant-A
-      vrfs:
-        - name: ospf-vrf
-          vrf_id: 2
-          ospf:
-            enabled: true
--           process_id: 101
-+           process_id: 102 # cannot use same value as underlay_ospf_process_id
-```
-
-### Removal of design.type
-
-In AVD 5.x, the variable `design.type` was used to select between different variants of default values for `node_type_keys`.
-
-As of AVD 6.x, the `design.type` variable has been removed. The default values of `node_type_keys` combine all the default node type from all designs.
-
-```diff
-# Remove the design.type setting
-- design:
--   type: l2ls
-```
-
-### Removal of default `bgp_ecmp` value
-
-In AVD 5.x, `bgp_ecmp` had a default value of 4 except for WAN routers where there was no default value.
-
-Starting AVD 6.0.0, the default value for `bgp_ecmp` has been removed to take advantage of the default value in EOS,
-which will be the maximum supported ECMP routes for the platform.
-Now `bgp_ecmp` must be explicitly defined if required.
-
-To retain the previous behavior, set the value explicitly in your input variables:
-
-```diff
-+ bgp_ecmp: 4
-```
-
-### eAPI is not enabled by default anymore in eos_designs
-
-In previous versions, `management_eapi.enabled` was `true` by default.
-
-In AVD 6.0, this is not the case anymore and eAPI needs to be explicitly enabled as follows:
-
-```diff
-management_eapi:
-+ enabled: true
-  enable_https: true
-```
-
-### A management IP or IPv6 is now required to enable eAPI when `default_mgmt_method: oob`
-
-Before AVD 6.x, it was possible to enable eAPI without setting `mgmt_ip` or `ipv6_mgmt_ip` when the default management method was set to out-of-band (which is the default) `default_mgmt_method: oob` and `management_eapi.vrfs` was not set.
-
-Starting AVD 6.0, enabling eAPI when the default management method is set to `oob` and `management_eapi.vrfs` is not set will raise an error if neither `mgmt_ip` nor `ipv6_mgmt_ip` are defined.
-Below changes should be noted to migrate to AVD 6.0 without errors.
-
-```diff
-type: l2leaf
-
-management_eapi:
-+ enabled: true # This must be set for management_eapi to take effect.
-  enable_https: true
-
-l2leaf:
-  nodes:
-    - name: management-eapi-host
-      id: 1
-+     mgmt_ip: 10.10.10.1/8
-```
-
-### Removal of setting `overlay_rd_type.admin_subfield` to `router_id` on invalid IPv4 address entry
-
-In AVD 5.x, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would set the value to `router_id` ignoring a potential input typo.
-
-Starting AVD 6.0.0, setting invalid ipv4 address in `overlay_rd_type.admin_subfield` would raise a validation error.
-
-To retain the previous behavior, set the value explicitly in your input variables:
-
-```diff
-overlay_rd_type:
-+ admin_subfield: router_id
-```
-
-### New eos_designs schema restrictions
-
-Starting AVD 6.0.0, the following data model keys will have defined restrictions in `eos_designs`.
-
-| Keys | New Restrictions |
-| ---- | ---------------- |
-| `aaa_settings.accounting.commands.console[].type` | required |
-| `aaa_settings.accounting.commands.default[].type` | required |
-| `aaa_settings.accounting.exec.default.type` | required |
-| `aaa_settings.accounting.system.default.type` | required |
-| `default_interfaces[].mlag_interfaces_speed` | Added valid_values |
-| `default_interfaces[].uplink_interface_speed` | Added valid_values |
-| `<custom_connected_endpoints_keys.key>[].adapters[].speed` | Added valid_values |
-| `network_ports[].switches` | min_length: 1 |
-| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].address_family` | required |
-| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].route_target` | required |
-| `"<network_services_keys.name>[].vrfs[].additional_route_targets[].type` | required |
-| `<network_services_keys.name>[].vrfs[].l3_interfaces[].ospf.message_digest_keys[].id` | Primary key |
-| `<network_services_keys.name>[].vrfs[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
-| `<network_services_keys.name>[].vrfs[].l3_port_channels[].ospf.message_digest_keys[].id` | Primary key |
-| `<network_services_keys.name>[].vrfs[].svis[].ospf.message_digest_keys[].id` | Primary key |
-| `<network_services_keys.name>[].vrfs[].svis[].nodes[].ospf.message_digest_keys[].id` | Primary key |
-| `<node_type_keys.key>.defaults.uplink_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].nodes[].uplink_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].uplink_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.nodes[].uplink_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.defaults.uplink_switch_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].nodes[].uplink_switch_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].uplink_switch_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.nodes[].uplink_switch_interface_speed` | Added valid_values |
-| `<node_type_keys.key>.defaults.mlag_interfaces_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].nodes[].mlag_interfaces_speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].mlag_interfaces_speed` | Added valid_values |
-| `<node_type_keys.key>.nodes[].mlag_interfaces_speed` | Added valid_values |
-| `<node_type_keys.key>.defaults.l3_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].nodes[].l3_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].l3_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.nodes[].l3_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.defaults.l3_port_channels[].member_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].nodes[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.node_groups[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
-| `<node_type_keys.key>.nodes[].l3_port_channels[].member_interfaces[].speed` | Added valid_values |
-| `p2p_links[].description` | min_length: 2, max_length: 2 |
-| `p2p_links[].interfaces` | min_length: 2, max_length: 2 |
-| `p2p_links[].ip` | min_length: 2, max_length: 2 |
-| `p2p_links[].nodes` | min_length: 2, max_length: 2 |
-| `p2p_links[].speed` | Added valid_values |
-| `svi_profiles[].ospf.message_digest_keys[].id` | Primary key |
-| `svi_profiles[].nodes[].ospf.message_digest_keys[].id` | Primary key |
-
-### Default management interface changed for cEOS platforms
-
-Starting AVD 6.0.0, the default management interface for cEOS and cEOSLab platforms has been changed from `Management0` to `Management1`.
-
-This change was made because `Management0` in EOS is handled as a virtual interface used in chassis, which limits the possible configuration on it.
-
-If you need to continue using `Management0` for cEOS platforms, you can override this using `custom_platform_settings`:
-
-```diff
-+custom_platform_settings:
-+  - platforms:
-+      - CEOS
-+      - cEOS
-+      - ceos
-+      - cEOSLab
-+    management_interface: Management0
-```
-
-### Removal of default Jinja2 templates for `interface_descriptions` and `ip_addressing` in eos_designs
-
-Starting AVD 6.0.0, the default templates for `interface_descriptions` and `ip_addressing` are removed from the eos_designs role. Custom templates may still be provided, but the role no longer includes built-in templates.
-
-The removed default templates for ip_addressing are:
-
-```diff
-- avd-v2-spine-p2p-uplinks-ip.j2
-- avd-v2-spine-p2p-uplinks-peer-ip.j2
-- mlg-ibgp-peering-ip-primary.j2
-- mlg-ibgp-peering-ip-secondary.j2
-- mlag-ip-primary.j2
-- mlag-ip-secondary.j2
-- mlag-l3-ip-primary.j2
-- mlag-l3-ip-secondary.j2
-- p2p-uplinks-ip.j2
-- p2p-uplinks-peer-ip.j2
-- router-id-ipv6.j2
-- router-id.j2
-- vtep-ip-mlag.j2
-- vtep-ip.j2
-```
-
-The removed default templates for interface_descriptions are:
-
-```diff
-- connected_endpoints/ethernet-interfaces.j2
-- connected_endpoints/port-channel-interfaces.j2
-- loopback_interfaces/overlay-loopback.j2
-- loopback_interfaces/vtep-loopback.j2
-- mlag/ethernet-interfaces.j2
-- mlag/port-channel-interfaces.j2
-- underlay/ethernet-interfaces.j2
-- underlay/port-channel-interfaces.j2
-```
-
-For migration cases where you must retain legacy logic, copy the required templates from the AVD 5.7 `roles/eos_designs/templates` into a custom template location and reference them explicitly.
-
-As an example, copy the templates to a directory `custom_templates` (make sure it is available in the search paths when the Ansible playbook is executing as [documented here](https://docs.ansible.com/ansible/latest/playbook_guide/playbook_pathing.html)) and update your input variables as follows:
-
-```diff
-node_type_keys:
-  - key: spine
-    type: spine
-    ip_addressing:
-+     p2p_uplinks_ip: 'custom_templates/ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2'
-    interface_descriptions:
-+     underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
-```
-
-### Removing support for templating of internal `switch.*` variables in Jinja templates
-
-Starting AVD 6.0.0, Jinja templates will no longer have access to internal AVD variables previously exposed as `switch.*`.
-This also applies to inline Jinja templates in the input variables (like host vars, group vars, task vars and play vars).
-
-Examples of variables that can no longer be used:
-
-- `{{ switch.id }}`
-- `{{ switch.mgmt_ip }}`
-- `{{ switch.mgmt_interface }}`
-
-For custom IP Addressing or Interface Description templates, refer to the [documentation](../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#context-for-ip_addressing-templates) for the available variables.
-
-Also refer to the documentation to see all the new models that may resolve the need for inline jinja templating.
-Several of the new AVD models provide abstractions like `default_mgmt_method_ip` or `default_mgmt_method_vrf`,
-which are intended to remove the need for inline Jinja templating in the input variables.
-
-If there is no alternative available for your current use case, please open a GitHub issue so we can work with you to identify alternatives.
-Users with a support agreement can contact Arista support to get assistance.
-
-### p2p_links now accepts a minimum and maximum of two entries
-
-In AVD 5.0.0, p2p_links list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
-
-Starting AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
-
-```diff
-# The same applies for core_interfaces
-l3_edge:
-  p2p_links:
--   - ip: [10.10.10.0/31, 10.10.10.1/31, 10.10.10.2/31, 10.10.10.3/31]
--     nodes: [peer1, peer2, peer3, peer4]
--     interfaces: [Ethernet1, Ethernet1, Ethernet1, Ethernet1]
--     descriptions: ["Custom description peer1", "Custom description peer2", "Custom description peer3",  "Custom description peer4"]
-+   - ip: [10.10.10.0/31, 10.10.10.1/31]
-+     nodes: [peer1, peer2]
-+     interfaces: [Ethernet1, Ethernet1]
-+     descriptions: ["Custom description peer1", "Custom description peer2"]
-+   - ip: [10.10.10.2/31, 10.10.10.3/31]
-+     nodes: [peer3, peer4]
-+     interfaces: [Ethernet1, Ethernet1]
-+     descriptions: ["Custom description peer3", "Custom description peer4"]
-  p2p_links_profiles:
--   - ip: [10.10.10.0/31, 10.10.10.1/31, 10.10.10.2/31, 10.10.10.3/31]
--     nodes: [peer1, peer2, peer3, peer4]
--     interfaces: [Ethernet1, Ethernet1, Ethernet1, Ethernet1]
--     descriptions: ["Custom description peer1", "Custom description peer2", "Custom description peer3", "Custom description peer4"]
-+   - ip: [10.10.10.0/31, 10.10.10.1/31]
-+     nodes: [peer1, peer2]
-+     interfaces: [Ethernet1, Ethernet1]
-+     descriptions: ["Custom description peer1", "Custom description peer2"]
-+   - ip: [10.10.10.2/31, 10.10.10.3/31]
-+     nodes: [peer3, peer4]
-+     interfaces: [Ethernet1, Ethernet1]
-+     descriptions: ["Custom description peer3", "Custom description peer4"]
-```
-
-### Removed autoconversion of `bgp_as` from float under node config
-
-In AVD 5.x.x, the `bgp_as` value under node configuration was automatically converted from a float to a string. This could lead to unintended truncation, for example, `65000.100` being interpreted as `65000.1`.
-
-Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
-To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.
-
-This change applies to below instances of bgp_as:
-
-- node_type.defaults
-- node_type.defaults.evpn_gateway.remote_peers
-- node_type.defaults.ipvpn_gateway.remote_peers
-
-```diff
-node_type:
-  defaults:
--   bgp_as: 65000.100
-+   bgp_as: "65000.100"
-    evpn_gateway:
-      remote_peers:
--       bgp_as: 65000.100
-+       bgp_as: "65000.100"
-    ipvpn_gateway:
-      remote_peers:
--       bgp_as: 65000.100
-+       bgp_as: "65000.100"
-```
-
-### Changing behavior of cv_topology and use_cv_topology
-
-The behavior of `cv_topology` and `use_cv_topology` has been changed in the following areas:
-
-- `use_cv_topology: true` now requires `cv_topology_levels` to describe the relationships between devices of each node type, instead of relying on `default_interfaces` to infer this.
-- MLAG peer interfaces are now set to all interfaces towards the MLAG peer.
-- `use_cv_topology: true` can no longer be combined with manually setting `uplink_interfaces`, `uplink_switches`, `uplink_switch_interfaces` or `mlag_interfaces`.
-
-```diff
-use_cv_topology: true
-+cv_topology_levels:
-+  - type: super-spine
-+    level: 1
-+  - type: spine
-+    level: 2
-+  - type: l3leaf
-+    level: 3
-+  - type: l2leaf
-+    level: 4
-+  - type: overlay-controller
-+    level: 5
--default_interfaces:
--  <...>
-cv_topology:
-  <...>
-```
-
-See the [documentation](../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#cloudvision-topology-settings) for `cv_topology` for details on the new behavior.
-
-### Fixed IP extended community list and route map for EVPN-SOO
-
-In AVD 6.0, when `vtep_loopback` is set to `Loopback0`, the IP extended community list and route map for EVPN SOO is corrected to use the Loopback0 IP address.
-
-### Change of default behavior for `evpn_prevent_readvertise_to_server`
-
-In AVD 5.x.x, enabling `evpn_prevent_readvertise_to_server` would configure an outbound route-map towards EVPN route-servers that would filter out BGP updates learned directly from the ASN of the route-server. This approach would not filter out routes learned via any other peer, even if they had the route-server's ASN in the AS-path.
-
-As of AVD 6.0.0, the new key `evpn_prevent_readvertise_to_server_mode` was introduced to control the mode of matching specific routes to be filtered out. The new default mode `as_path_acl` now relies on the route-map with `as-path access-list` to filter out BGP updates with the route-server ASN anywhere in the AS-path.
-
-To retain the previous behavior when enabling `evpn_prevent_readvertise_to_server`, the following change is required:
-
-```diff
-+ evpn_prevent_readvertise_to_server_mode: source_peer_asn
-```
-
-### `vtep_diagnostic` change of default behavior for `loopback_ip_pools`, `loopback_ip_range` and `loopback_ipv6_range` under network services
-
-In AVD 5.x.x, `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools` under `vtep_diagnostic` under network services.
-
-As of AVD 6.0.0, if the POD name defined for a device is matching an entry under `loopback_ip_pools`, this entry will take precedence over `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPV6.
-
-To retain the previous behavior remove the pool under `loopback_ip_pools` where `pod` is matching `pod_name`.
-
-```diff
-  pod_name: TENANT_NETWORKS_POD
-  tenants:
-    - name: Tenant_X
-      mac_vrf_vni_base: 11000
-      vrfs:
-        - name: VRF_with_loopback_ip_pools
-          vrf_id: 22
-          vtep_diagnostic:
-            loopback: 200
-            loopback_ip_pools:
--             - pod: TENANT_NETWORKS_POD
--               ipv4_pool: 10.101.102.0/24
--               ipv6_pool: 2001:db8:1::-2001:db8:1:7fff::
-              - pod: OTHER_POD
-                ipv4_pool: 10.101.103.0/24
-            loopback_ip_range: 10.255.1.0/24
-            loopback_ipv6_range: 2001:db8:1::-2001:db8:1:7fff::
-```
-
-### Changes in local user structured configuration for `no_password` and `disabled`
-
-In AVD 5.x.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
-
-Starting AVD 6.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
-
 ### Changes in validation requirements for CV Pathfinder WAN routers
 
 In AVD 5.x.x, WAN routers operating in `cv_pathfinder` mode could be configured without defining `wan_route_servers`, which could result in incomplete or invalid configurations.
 
-Starting AVD 6.0, `wan_route_servers` must be configured for WAN routers operating in `cv_pathfinder` mode. If `wan_route_servers` is not defined, AVD will raise a validation error, as this configuration is required for proper CV Pathfinder operation.
+Starting AVD 6.0.0, `wan_route_servers` must be configured for WAN routers operating in `cv_pathfinder` mode. If `wan_route_servers` is not defined, AVD will raise a validation error, as this configuration is required for proper CV Pathfinder operation.
 
 ```diff
 + wan_route_servers:
 +  - hostname: uplink_lan_wan_router1
 ```
-
-### Change in default feature support of `bgp_update_wait_install` on DCS-7358X4
-
-In previous versions of AVD, the value of `bgp_update_wait_install` was set to `false` by default. In AVD 6.0.0 this is now set to `true` by default.
-
-### Change in default value of `maximum-routes` for underlay bgp peer groups
-
-In previous versions of AVD, the value of `maximum_routes` for underlay `bgp_peer_groups` was hardcoded to `12000` by default.
-
-Starting AVD 6.0, new knobs `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` are introduced for setting maximum_routes, with a default value of `256000`.
-
-To retain the previous behavior, `maximum_routes` can be set to `12000` under `bgp_peer_groups.ipv4_underlay_peers.maximum_routes`, `bgp_peer_groups.mlag_ipv4_underlay_peer.maximum_routes` and `bgp_peer_groups.mlag_ipv4_vrfs_peer.maximum_routes` for the particular peer-group.
-
-```diff
-bgp_peer_groups:
-  ipv4_underlay_peers:
-+   maximum_routes: 12000
-  mlag_ipv4_underlay_peer:
-+   maximum_routes: 12000
-  mlag_ipv4_vrfs_peer:
-+   maximum_routes: 12000
-```
-
-### Changes in validation requirements for CloudVision clusters
-
-In AVD 5.x.x, CloudVision clusters could be configured without enforcing the presence of NTP or DNS settings, even when servers were defined using DNS names.
-
-Starting AVD 6.0, additional validation is enforced when CloudVision clusters (on-prem or CVaaS) are configured:
-
-- `ntp_settings.servers` must be configured whenever any CloudVision cluster `cv_settings.cvaas.clusters[]` or `cv_settings.onprem_clusters[].servers[]` are defined.
-- `dns_settings.servers` must be configured when CVaaS clusters `cv_settings.cvaas.clusters[]` are defined.
-- `dns_settings.servers` must be configured for on-prem clusters if any server under `cv_settings.onprem_clusters[].servers[].name` is specified using a DNS name.
-
-These validations ensure that required infrastructure dependencies are explicitly configured when deploying CloudVision clusters.
 
 ### New 802.1X configuration model
 
@@ -1272,6 +1177,93 @@ aaa_settings:
 +   # bypass_lldp: true
 +   # redistribute_in_evpn: true
 ```
+
+### Custom keys starting without `_` in structured config are no longer supported
+
+In AVD 5.x, custom keys starting with or without `_` were accepted in structured config.
+
+Starting AVD 6.0.0, only custom keys that begin with `_` are accepted in structured config.
+
+```diff
+l3leaf:
+  nodes:
+    - name: host1
+      id: 101
+      bgp_as: 101
+      structured_config:
+-        custom_key: [ custom_value ]
++        _custom_key: [ custom_value ]
+```
+
+### Removal of default Jinja2 templates for `interface_descriptions` and `ip_addressing` in eos_designs
+
+Starting AVD 6.0.0, the default templates for `interface_descriptions` and `ip_addressing` are removed from the eos_designs role. Custom templates may still be provided, but the role no longer includes built-in templates.
+
+The removed default templates for ip_addressing are:
+
+```diff
+- avd-v2-spine-p2p-uplinks-ip.j2
+- avd-v2-spine-p2p-uplinks-peer-ip.j2
+- mlg-ibgp-peering-ip-primary.j2
+- mlg-ibgp-peering-ip-secondary.j2
+- mlag-ip-primary.j2
+- mlag-ip-secondary.j2
+- mlag-l3-ip-primary.j2
+- mlag-l3-ip-secondary.j2
+- p2p-uplinks-ip.j2
+- p2p-uplinks-peer-ip.j2
+- router-id-ipv6.j2
+- router-id.j2
+- vtep-ip-mlag.j2
+- vtep-ip.j2
+```
+
+The removed default templates for interface_descriptions are:
+
+```diff
+- connected_endpoints/ethernet-interfaces.j2
+- connected_endpoints/port-channel-interfaces.j2
+- loopback_interfaces/overlay-loopback.j2
+- loopback_interfaces/vtep-loopback.j2
+- mlag/ethernet-interfaces.j2
+- mlag/port-channel-interfaces.j2
+- underlay/ethernet-interfaces.j2
+- underlay/port-channel-interfaces.j2
+```
+
+For migration cases where you must retain legacy logic, copy the required templates from the AVD 5.7 `roles/eos_designs/templates` into a custom template location and reference them explicitly.
+
+As an example, copy the templates to a directory `custom_templates` (make sure it is available in the search paths when the Ansible playbook is executing as [documented here](https://docs.ansible.com/ansible/latest/playbook_guide/playbook_pathing.html)) and update your input variables as follows:
+
+```diff
+node_type_keys:
+  - key: spine
+    type: spine
+    ip_addressing:
++     p2p_uplinks_ip: 'custom_templates/ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2'
+    interface_descriptions:
++     underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
+```
+
+### Removing support for templating of internal `switch.*` variables in Jinja templates
+
+Starting AVD 6.0.0, Jinja templates will no longer have access to internal AVD variables previously exposed as `switch.*`.
+This also applies to inline Jinja templates in the input variables (like host vars, group vars, task vars and play vars).
+
+Examples of variables that can no longer be used:
+
+- `{{ switch.id }}`
+- `{{ switch.mgmt_ip }}`
+- `{{ switch.mgmt_interface }}`
+
+For custom IP Addressing or Interface Description templates, refer to the [documentation](../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#context-for-ip_addressing-templates) for the available variables.
+
+Also refer to the documentation to see all the new models that may resolve the need for inline jinja templating.
+Several of the new AVD models provide abstractions like `default_mgmt_method_ip` or `default_mgmt_method_vrf`,
+which are intended to remove the need for inline Jinja templating in the input variables.
+
+If there is no alternative available for your current use case, please open a GitHub issue so we can work with you to identify alternatives.
+Users with a support agreement can contact Arista support to get assistance.
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
@@ -1650,7 +1642,7 @@ ntp:
 
 In AVD 5.x, IPv6 OSPF area on VLAN interfaces was configured using the key `ipv6_ospf_area`. This structure did not allow the definition of the OSPF Process ID, which could result in incomplete or incorrect EOS commands being generated. Additionally, the interface network type was configured using the standalone key `ipv6_ospf_network_point_to_point`.
 
-Starting with AVD 6.0, `ipv6_ospf_area` has been replaced by the dictionary `ipv6_ospf.process.area`. This change allows defining both the Process ID and area explicitly. The interface network type configuration has also been moved under the same dictionary as `network_point_to_point`. These changes ensure the correct EOS command `ipv6 ospf <process-id> area <area-id>` is generated and keep all IPv6 OSPF related settings grouped together.
+Starting with AVD 6.0.0, `ipv6_ospf_area` has been replaced by the dictionary `ipv6_ospf.process.area`. This change allows defining both the Process ID and area explicitly. The interface network type configuration has also been moved under the same dictionary as `network_point_to_point`. These changes ensure the correct EOS command `ipv6 ospf <process-id> area <area-id>` is generated and keep all IPv6 OSPF related settings grouped together.
 
 ```diff
 vlan_interfaces:

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -77,7 +77,8 @@ was the output of `str` on each items. This could lead to inconsistent behavior 
 
 ### Removal of deprecated AVD Design (eos_designs) data models
 
-The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0.
+The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0. 
+#TODO: we should add a sentence about reviewing the new model and updating your input variables accordingly.
 
 | Removed key | New key |
 | ----------- | ------- |
@@ -143,6 +144,7 @@ The following data model keys have been removed from AVD Design (`eos_designs`) 
 | `underlay_ospf_authentication.message_digest_keys[].key` | `underlay_ospf_authentication.message_digest_keys[].cleartext_key` |
 
 ### New AVD Design (eos_designs) schema restrictions
+#TODO: Here we also need a sentence on what to do with this information.
 
 Starting with AVD 6.0.0, the following data model keys will have defined restrictions in AVD Design (`eos_designs`).
 

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -78,7 +78,7 @@ was the output of `str` on each items. This could lead to inconsistent behavior 
 ### Removal of deprecated AVD Design (eos_designs) data models
 
 The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0.
-# TODO: we should add a sentence about reviewing the new model and updating your input variables accordingly.
+TODO: we should add a sentence about reviewing the new model and updating your input variables accordingly.
 
 | Removed key | New key |
 | ----------- | ------- |
@@ -145,7 +145,7 @@ The following data model keys have been removed from AVD Design (`eos_designs`) 
 
 ### New AVD Design (eos_designs) schema restrictions
 
-# TODO: Here we also need a sentence on what to do with this information.
+TODO: Here we also need a sentence on what to do with this information.
 
 Starting with AVD 6.0.0, the following data model keys will have defined restrictions in AVD Design (`eos_designs`).
 

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -59,19 +59,6 @@ This is no longer needed as the extensions are automatically loaded in `pyavd` w
 -jinja2_extensions = jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
 ```
 
-## Removal of Ansible components
-
-The following Ansible components have been removed from the `arista.avd` Ansible collection in version 6.0.0.
-
-| Component type | Name | Replacement |
-| -------------- | ---- | ----------- |
-| Action plugin/Module | `arista.avd.configlet_build_config` | The internal `arista.avd.configlet_build_config` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
-| Action plugin/Module | `arista.avd.inventory_to_container` | The internal `arista.avd.inventory_to_container` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
-| Role | `arista.avd.dhcp_provisioner` | The role is not compatible with modern DHCP servers and should not be used for production. The `arista.avd.dhcp_provisioner` role is released as open source, so it can be copied and reused according to the license and copyright. |
-| Role | `arista.avd.eos_config_deploy_cvp` | Migrate to `arista.avd.cv_deploy`. See the [detailed porting guide](../howto/migrate-to-cv-deploy.md) for instructions. |
-| Role | `arista.avd.cvp_configlet_upload` | Migrate to `arista.avd.cv_deploy`. See the [detailed porting guide](../howto/migrate-to-cv-deploy.md) for instructions. |
-| Role | `arista.avd.eos_validate_state` | Migrate to `arista.avd.anta_runner`. See the [how-to guide](../howto/migrate-to-anta-runner.md) for instructions. |
-
 ## Changes to Ansible filter plugin arista.avd.natural_sort
 
 In AVD 6.0.0, `sort_key` is now mandatory when sorting list of dictionaries using `arista.avd.natural_sort`. Previously, `sort_key` was not required and when omitted, the key used to sort

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -77,8 +77,8 @@ was the output of `str` on each items. This could lead to inconsistent behavior 
 
 ### Removal of deprecated AVD Design (eos_designs) data models
 
-The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0. 
-#TODO: we should add a sentence about reviewing the new model and updating your input variables accordingly.
+The following data model keys have been removed from AVD Design (`eos_designs`) date model in AVD 6.0.0.
+# TODO: we should add a sentence about reviewing the new model and updating your input variables accordingly.
 
 | Removed key | New key |
 | ----------- | ------- |
@@ -144,7 +144,8 @@ The following data model keys have been removed from AVD Design (`eos_designs`) 
 | `underlay_ospf_authentication.message_digest_keys[].key` | `underlay_ospf_authentication.message_digest_keys[].cleartext_key` |
 
 ### New AVD Design (eos_designs) schema restrictions
-#TODO: Here we also need a sentence on what to do with this information.
+
+# TODO: Here we also need a sentence on what to do with this information.
 
 Starting with AVD 6.0.0, the following data model keys will have defined restrictions in AVD Design (`eos_designs`).
 

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -545,7 +545,7 @@ In AVD 5.x, `no_password: true` was always rendered in the structured configurat
 
 Starting with AVD 6.0.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
 
-### eAPI is not enabled by default anymore in eos_designs
+### eAPI is no longer enabled by default in eos_designs
 
 In previous versions, `management_eapi.enabled` was `true` by default.
 
@@ -582,7 +582,7 @@ l2leaf:
 
 Starting with AVD 6.0.0, the default management interface for cEOS and cEOSLab platforms has been changed from `Management0` to `Management1`.
 
-This change was made because `Management0` in EOS is handled as a virtual interface used in chassis, which limits the possible configuration on it.
+This change was made because EOS handles `Management0` as a virtual interface used in a chassis, which limits the possible configurations on it.
 
 If you need to continue using `Management0` for cEOS platforms, you can override this using `custom_platform_settings`:
 
@@ -1245,7 +1245,7 @@ which are intended to remove the need for inline Jinja templating in the input v
 If there is no alternative available for your current use case, please open a GitHub issue so we can work with you to identify alternatives.
 Users with a support agreement can contact Arista support to get assistance.
 
-## Changes to role `arista.avd.eos_cli_config_gen`
+## Changes to the Ansible role `arista.avd.eos_cli_config_gen`
 
 ### Removal of deprecated EOS Config (eos_cli_config_gen) data models
 

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -2,7 +2,7 @@
 
 # This title is used for search results
 
-title: Porting Guide for Ansible AVD 6.x.x
+title: Porting Guide for AVD 6.x.x
 ---
 <!--
   ~ Copyright (c) 2025-2026 Arista Networks, Inc.
@@ -10,7 +10,7 @@ title: Porting Guide for Ansible AVD 6.x.x
   ~ that can be found in the LICENSE file.
   -->
 
-# Porting Guide for Ansible AVD 6.x.x
+# Porting Guide for AVD 6.x.x
 
 Major releases of AVD can contain breaking changes. This porting guide addresses how to update your inventory
 and playbooks to be compatible with new default behaviors and changed data models when upgrading from AVD 5.x versions.

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -161,7 +161,6 @@ The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
 | `underlay_mutlticast` | `underlay_mutlticast_pim_sm` or `<node_type_key>.defaults.underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.node_groups[].nodes[].underlay_multicast.pim_sm.enabled` or `<node_type_key>.nodes[].underlay_multicast.pim_sm.enabled` |
 | `underlay_ospf_authentication.message_digest_keys[].key` | `underlay_ospf_authentication.message_digest_keys[].cleartext_key` |
 
-
 ### New eos_designs schema restrictions
 
 Starting AVD 6.0.0, the following data model keys will have defined restrictions in `eos_designs`.

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -373,7 +373,7 @@ l3_edge:
   p2p_links:
     - id: 1
       nodes: [mlag-leaf-1, peer]
-      # This configuration is accepted in AVD 5.x.x
+      # This configuration is accepted in AVD 5.x
       interfaces: [Ethernet3, Ethernet1]
       include_in_underlay_protocol: false
 ```
@@ -454,7 +454,7 @@ These keys are now removed and replaced with `cv_settings`, to build a similar o
 
 ### Changes in validation requirements for CloudVision clusters
 
-In AVD 5.x.x, CloudVision clusters could be configured without enforcing the presence of NTP or DNS settings, even when servers were defined using DNS names.
+In AVD 5.x, CloudVision clusters could be configured without enforcing the presence of NTP or DNS settings, even when servers were defined using DNS names.
 
 Starting with AVD 6.0.0, additional validation is enforced when CloudVision clusters (on-prem or CVaaS) are configured:
 
@@ -560,7 +560,7 @@ snmp_settings:
 
 ### Changes in local user structured configuration for `no_password` and `disabled`
 
-In AVD 5.x.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
+In AVD 5.x, `no_password: true` was always rendered in the structured configuration even if `sha512_password` was set, and even if `disabled: true` was configured for a local user, all other fields were still rendered in the structured configuration.
 
 Starting with AVD 6.0.0, if `sha512_password` or `cleartext_password` is set, `no_password` is not rendered in the structured configuration, and if `disabled: true` is configured for a local user, other fields are not rendered in the structured configuration.
 
@@ -723,7 +723,7 @@ l3_edge:
 
 ### `core_interfaces.p2p_links` or `l3_edge.p2p_links` list keys now accepts a minimum and maximum of two entries
 
-In AVD 5.0.0, `core_interfaces.p2p_links` or `l3_edge.p2p_links` list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
+In AVD 5.x, `core_interfaces.p2p_links` or `l3_edge.p2p_links` list keys `nodes`, `ip`, `interfaces` and `descriptions` did not have any limitation in size. This was sometimes working but could lead to undefined behavior as all the code was written to work for exactly `2` nodes, in particular when figuring out the peer device.
 
 Starting with AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
 
@@ -786,7 +786,7 @@ It may not be possible to retain the old behavior if you had a mix and match of 
 
 ### Removed autoconversion of `bgp_as` from float under node config
 
-In AVD 5.x.x, the `bgp_as` value under node configuration was automatically converted from a float to a string. This could lead to unintended truncation, for example, `65000.100` being interpreted as `65000.1`.
+In AVD 5.x, the `bgp_as` value under node configuration was automatically converted from a float to a string. This could lead to unintended truncation, for example, `65000.100` being interpreted as `65000.1`.
 
 Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
 To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.
@@ -849,7 +849,7 @@ overlay_rd_type:
 
 ### Change of default behavior for `evpn_prevent_readvertise_to_server`
 
-In AVD 5.x.x, enabling `evpn_prevent_readvertise_to_server` would configure an outbound route-map towards EVPN route-servers that would filter out BGP updates learned directly from the ASN of the route-server. This approach would not filter out routes learned via any other peer, even if they had the route-server's ASN in the AS-path.
+In AVD 5.x, enabling `evpn_prevent_readvertise_to_server` would configure an outbound route-map towards EVPN route-servers that would filter out BGP updates learned directly from the ASN of the route-server. This approach would not filter out routes learned via any other peer, even if they had the route-server's ASN in the AS-path.
 
 As of AVD 6.0.0, the new key `evpn_prevent_readvertise_to_server_mode` was introduced to control the mode of matching specific routes to be filtered out. The new default mode `as_path_acl` now relies on the route-map with `as-path access-list` to filter out BGP updates with the route-server ASN anywhere in the AS-path.
 
@@ -861,7 +861,7 @@ To retain the previous behavior when enabling `evpn_prevent_readvertise_to_serve
 
 ### Network services VRFs configuration for `vtep_diagnostic` change of default behavior for `loopback_ip_pools`, `loopback_ip_range` and `loopback_ipv6_range`
 
-In AVD 5.x.x, under network services VRFs configuration for `vtep_diagnostic`; `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools`.
+In AVD 5.x, under network services VRFs configuration for `vtep_diagnostic`; `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPv6 take precedence over `loopback_ip_pools`.
 
 As of AVD 6.0.0, if the POD name defined for a device is matching an entry under `loopback_ip_pools`, this entry will take precedence over `loopback_ip_range` for IPv4 and `loopback_ipv6_range` for IPV6.
 
@@ -1032,7 +1032,7 @@ aaa_settings:
 
 ### Change of the default behavior for PIM-SM multicast for `core_interfaces.p2p_links` and `l3_edge.p2p_links`
 
-In AVD 5.x.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
+In AVD 5.x, enabling PIM-SM on a `core_interface` or `l3_edge` link required all of the following settings:
 
 - `underlay_multicast: true` at the global level
 - `underlay_multicast: true` **and** `include_in_underlay_protocol: true` at the link or profile level
@@ -1168,7 +1168,7 @@ To retain the previous behavior, for instance because your device does not suppo
 
 ### Changes in validation requirements for CV Pathfinder WAN routers
 
-In AVD 5.x.x, WAN routers operating in `cv_pathfinder` mode could be configured without defining `wan_route_servers`, which could result in incomplete or invalid configurations.
+In AVD 5.x, WAN routers operating in `cv_pathfinder` mode could be configured without defining `wan_route_servers`, which could result in incomplete or invalid configurations.
 
 Starting with AVD 6.0.0, `wan_route_servers` must be configured for WAN routers operating in `cv_pathfinder` mode. If `wan_route_servers` is not defined, AVD will raise a validation error, as this configuration is required for proper CV Pathfinder operation.
 
@@ -1724,7 +1724,7 @@ As of AVD 6.0.0, `router_isis.set_overload_bit.enabled` must be set to generate 
 
 ### Traffic policy named counters must now be explicitly defined under `traffic_policies.policies[].counters`
 
-In AVD 5.0.0, named counters were generated automatically based on the `traffic_policies.policies[].matches[].actions[].count` key.
+In AVD 5.x, named counters were generated automatically based on the `traffic_policies.policies[].matches[].actions[].count` key.
 
 Starting with AVD 6.0.0, this automatic generation has been removed. All named counters must be defined under the new `traffic_policies.policies[].counters` key.
 

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -79,6 +79,10 @@ for details.
 | ------------------------------------------ |
 | [Removal of deprecated eos\_designs data models](../porting-guides/6.x.x.md#removal-of-deprecated-eos_designs-data-models) |
 
+#### Fixed IP extended community list and route map for EVPN-SOO
+
+In AVD 6.0.0, when `vtep_loopback` is set to `Loopback0`, the IP extended community list and route map for EVPN SOO is corrected to use the Loopback0 IP address.
+
 ### Breaking or behavioral changes in eos_cli_config_gen
 
 Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 6.x.x](../porting-guides/6.x.x.md#changes-to-role-aristaavdeos_cli_config_gen)

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -24,7 +24,8 @@ For additional information, please see [versioning](../versioning/semantic-versi
 
 - Python requirements:
   - PyAVD no longer requires the `cvprac`,  `treelib` and `jsonschema` libraries.
-  - PyAVD now requires the `pyavd-utils` library. It will be installed automatically when upgrading pyavd.
+  - PyAVD now requires the `anta` Python library as a core dependency.
+  - PyAVD now requires the `pyavd-utils` Python library. It will be installed automatically when upgrading pyavd.
   - PyAVD now requires the `cryptography` Python library to be version 43.0.0 or higher. It will be installed automatically when upgrading pyavd.
   - PyAVD now requires the `python-socks[asyncio]` Python library to be version 2.7.2 or higher. It will be installed automatically when upgrading pyavd.
   - PyAVD now supports ansible-core from **2.16.0** to **2.20.x**.

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -41,24 +41,16 @@ For additional information, please see [versioning](../versioning/semantic-versi
 
 ### Removal of Ansible components
 
-The following ansible components have been removed from the `arista.avd` Ansible collection in v6.0.0.
+The following Ansible components have been removed from the `arista.avd` Ansible collection in version 6.0.0.
 
-Filters:
-
-- `arista.avd.xxx`
-
-Action plugins / Modules:
-
-- `arista.avd.configlet_build_config`
-- `arista.avd.inventory_to_container`
-
-Roles:
-
-- `arista.avd.dhcp_provisioner`
-- `arista.avd.eos_config_deploy_cvp`
-- `arista.avd.cvp_configlet_upload`
-
-See the [porting guide](../porting-guides/6.x.x.md#removal-of-ansible-components) for details.
+| Component type | Name | Replacement |
+| -------------- | ---- | ----------- |
+| Action plugin/Module | `arista.avd.configlet_build_config` | The internal `arista.avd.configlet_build_config` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
+| Action plugin/Module | `arista.avd.inventory_to_container` | The internal `arista.avd.inventory_to_container` module is no longer used by AVD. The plugin is released as open source, so it can be copied and reused according to the license and copyright. |
+| Role | `arista.avd.dhcp_provisioner` | The role is not compatible with modern DHCP servers and should not be used for production. The `arista.avd.dhcp_provisioner` role is released as open source, so it can be copied and reused according to the license and copyright. |
+| Role | `arista.avd.eos_config_deploy_cvp` | Migrate to `arista.avd.cv_deploy`. See the [detailed porting guide](../howto/migrate-to-cv-deploy.md) for instructions. |
+| Role | `arista.avd.cvp_configlet_upload` | Migrate to `arista.avd.cv_deploy`. See the [detailed porting guide](../howto/migrate-to-cv-deploy.md) for instructions. |
+| Role | `arista.avd.eos_validate_state` | Migrate to `arista.avd.anta_runner`. See the [how-to guide](../howto/migrate-to-anta-runner.md) for instructions. |
 
 ### Example entry
 

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -77,7 +77,7 @@ for details.
 
 | Detailed changes and link to porting guide |
 | ------------------------------------------ |
-| [Removal of deprecated eos\_designs data models](../porting-guides/6.x.x.md#removal-of-deprecated-eos_designs-data-models) |
+| [Removal of deprecated eos\_designs data models](../porting-guides/6.x.x.md#removal-of-deprecated-avd-design-eos_designs-data-models) |
 
 #### Fixed IP extended community list and route map for EVPN-SOO
 
@@ -90,4 +90,4 @@ for details.
 
 | Detailed changes and link to porting guide |
 | ------------------------------------------ |
-| [Removal of deprecated eos\_cli\_config\_gen data models](../porting-guides/6.x.x.md#removal-of-deprecated-eos_cli_config_gen-data-models) |
+| [Removal of deprecated eos\_cli\_config\_gen data models](../porting-guides/6.x.x.md#removal-of-deprecated-eos-config-eos_cli_config_gen-data-models) |


### PR DESCRIPTION
## Change Summary

Review the porting guide for the 6.0.0 GA release

Note I did not improve release notes, this will be done in another PR.

## How to test

Review Documentation: https://ansible-avd--6513.org.readthedocs.build/en/6513/docs/porting-guides/6.x.x.html

## Checklist

- [x] group/re-org common changes in eos_designs
- [x]  group/re-org common changes in eos_cli_config_gen
- [x] review subtitles
- [x] improve description entries
- [x] moved relevant entries to release notes
