### PR TITLE
Doc: Remove howto artifacts with destroy sequence

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
@@ -15,3 +15,14 @@
         - intended
         - config_backup
         - reports
+
+    - name: Delete howto artifact folders
+      delegate_to: 127.0.0.1
+      run_once: true
+      ansible.builtin.file:
+        path: "{{ how_to_root_dir }}/{{ item }}"
+        state: absent
+      with_items:
+        - connected_endpoints/artifacts
+        - network_services/artifacts
+        - node_types/artifacts

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/all.yml
@@ -1,2 +1,3 @@
 ---
 root_dir: '{{ playbook_dir }}/inventory'
+how_to_root_dir: "{{ lookup('pipe', 'git rev-parse --show-toplevel') }}/docs/howto"


### PR DESCRIPTION
## Change Summary

Small quality of life PR and fixing a minor bug. Previously files would have to be manually deleted if file names changed. Now, the artifacts will be properly deleted and recreated like our previous folder delete task.

## Component(s) name

Docs

## Proposed changes

Please see change summary.

## How to test

Run the destroy and converge sequences. How-to artifacts should be deleted and recreated on converge.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
