### PR TITLE
Fix(eos_cli_config_gen): Fix the invalid ip radius and ip tacacs commands when source interface name not defined

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-radius-source-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-radius-source-interfaces.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ip_radius_source_interfaces</samp>](## "ip_radius_source_interfaces") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_radius_source_interfaces.[].name") | String |  |  |  | Interface Name. |
+    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_radius_source_interfaces.[].name") | String | Required |  |  | Interface Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_radius_source_interfaces.[].vrf") | String |  |  |  | VRF Name. |
 
 === "YAML"
@@ -17,7 +17,7 @@
     ip_radius_source_interfaces:
 
         # Interface Name.
-      - name: <str>
+      - name: <str; required>
 
         # VRF Name.
         vrf: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-tacacs-source-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-tacacs-source-interfaces.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ip_tacacs_source_interfaces</samp>](## "ip_tacacs_source_interfaces") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_tacacs_source_interfaces.[].name") | String |  |  |  | Interface name. |
+    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_tacacs_source_interfaces.[].name") | String | Required |  |  | Interface name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ip_tacacs_source_interfaces.[].vrf") | String |  |  |  |  |
 
 === "YAML"
@@ -17,6 +17,6 @@
     ip_tacacs_source_interfaces:
 
         # Interface name.
-      - name: <str>
+      - name: <str; required>
         vrf: <str>
     ```

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -1390,6 +1390,8 @@ Starting with AVD 6.0.0, the following EOS Configdata model keys will have defin
 | `ethernet_interfaces[].link_tracking.groups` | required, `min_length: 1` |
 | `ethernet_interfaces[].link_tracking_groups[].direction` | required |
 | `ethernet_interfaces[].speed` | Added valid_values |
+| `ip_radius_source_interfaces[].name` | required |
+| `ip_tacacs_source_interfaces[].name` | required |
 | `logging.level.severity` | required |
 | `logging.policy.match.match_lists[].action` | required |
 | `management_interfaces[].speed` | Added valid_values |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-radius-source-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-radius-source-interfaces.j2
@@ -10,8 +10,6 @@
 {%     if ip_radius_source_interface.vrf is arista.avd.defined %}
 {%         set ip_radius_cli = ip_radius_cli ~ " vrf " ~ ip_radius_source_interface.vrf %}
 {%     endif %}
-{%     if ip_radius_source_interface.name is arista.avd.defined %}
-{%         set ip_radius_cli = ip_radius_cli ~ " source-interface " ~ ip_radius_source_interface.name %}
-{%     endif %}
+{%     set ip_radius_cli = ip_radius_cli ~ " source-interface " ~ ip_radius_source_interface.name %}
 {{ ip_radius_cli }}
 {% endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-tacacs-source-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-tacacs-source-interfaces.j2
@@ -10,8 +10,6 @@
 {%     if ip_tacacs_source_interface.vrf is arista.avd.defined %}
 {%         set ip_tacacs_cli = ip_tacacs_cli ~ " vrf " ~ ip_tacacs_source_interface.vrf %}
 {%     endif %}
-{%     if ip_tacacs_source_interface.name is arista.avd.defined %}
-{%         set ip_tacacs_cli = ip_tacacs_cli ~ " source-interface " ~ ip_tacacs_source_interface.name %}
-{%     endif %}
+{%     set ip_tacacs_cli = ip_tacacs_cli ~ " source-interface " ~ ip_tacacs_source_interface.name %}
 {{ ip_tacacs_cli }}
 {% endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -17160,14 +17160,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {"name": {"type": str}, "vrf": {"type": str}}
-        name: str | None
+        name: str
         """Interface Name."""
         vrf: str | None
         """VRF Name."""
 
         if TYPE_CHECKING:
 
-            def __init__(self, *, name: str | None | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined) -> None:
+            def __init__(self, *, name: str | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined) -> None:
                 """
                 IpRadiusSourceInterfacesItem.
 
@@ -17680,13 +17680,13 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {"name": {"type": str}, "vrf": {"type": str}}
-        name: str | None
+        name: str
         """Interface name."""
         vrf: str | None
 
         if TYPE_CHECKING:
 
-            def __init__(self, *, name: str | None | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined) -> None:
+            def __init__(self, *, name: str | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined) -> None:
                 """
                 IpTacacsSourceInterfacesItem.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6699,6 +6699,7 @@ keys:
       keys:
         name:
           type: str
+          required: true
           description: Interface Name.
         vrf:
           type: str
@@ -6958,6 +6959,7 @@ keys:
       keys:
         name:
           type: str
+          required: true
           description: Interface name.
         vrf:
           type: str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
@@ -13,6 +13,7 @@ keys:
       keys:
         name:
           type: str
+          required: true
           description: Interface Name.
         vrf:
           type: str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
@@ -14,6 +14,7 @@ keys:
       keys:
         name:
           type: str
+          required: true
           description: Interface name.
         vrf:
           type: str


### PR DESCRIPTION
## Change Summary

Fix the invalid ip radius and ip tacacs commands when source interface name not defined

## Related Issue(s)

Fixes #6548 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix the invalid ip radius and ip tacacs commands when source interface name not defined

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
