### PR TITLE
Doc(eos_designs): Fix wrong indentation for prefix-list catalog

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -835,7 +835,7 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
 
 ## Catalogs
 
-### IPv4 extended ACLS Catalog
+### IPv4 extended ACLs Catalog
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-acls.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -833,13 +833,15 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/bfd-settings.md
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
 --8<--
 
-## IPv4 ACL settings
+## Catalogs
+
+### IPv4 extended ACLS Catalog
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-acls.md
 --8<--
 
-### IPv4 Prefix-List Catalog settings
+### IPv4 Prefix-List Catalog
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-prefix-list-catalog.md


### PR DESCRIPTION
## Change Summary

cf summary

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Everything under catalog

## How to test

readthedocs

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
