### PR TITLE
Doc: collections install path is incorrect/updated

### DIFF
--- a/docs/installation/collection-installation.md
+++ b/docs/installation/collection-installation.md
@@ -76,9 +76,11 @@ and update your `ansible.cfg`:
 ```shell
 # Install collection under ${PWD}/collections/
 $ ansible-galaxy collection install arista.avd -p collections/
+```
 
+```ini title="ansible.cfg"
 # Update ansible.cfg file
-$ vim ansible.cfg
+[defaults]
 collections_path = ${PWD}/collections:~/.ansible/collections:/usr/share/ansible/collections
 ```
 
@@ -110,7 +112,8 @@ See the [collection installation](#install-collection-from-ansible-galaxy) secti
 
 - By default, Ansible will issue a warning when a duplicate dict key is encountered in YAML. We recommend to change to error instead and stop playbook execution when a duplicate key is detected.
 
-```ini
+```ini title="ansible.cfg"
+[defaults]
 duplicate_dict_key=error
 ```
 

--- a/docs/installation/collection-installation.md
+++ b/docs/installation/collection-installation.md
@@ -79,7 +79,7 @@ $ ansible-galaxy collection install arista.avd -p collections/
 
 # Update ansible.cfg file
 $ vim ansible.cfg
-collections_paths = ${PWD}/collections:~/.ansible/collections:/usr/share/ansible/collections
+collections_path = ${PWD}/collections:~/.ansible/collections:/usr/share/ansible/collections
 ```
 
 ### Upgrade installed AVD collection


### PR DESCRIPTION
the variable for custom collection path installations has changed from collections_paths to collections_path

fixes #6578

## Change Summary

The variable for specifying custom collections paths has changed in later versions of ansible.  it should be:
`collections_path`

## Component(s) name

Documentation only

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
