### PR TITLE
Feat(eos_cli_config_gen): Router multicast ipv6 improvements

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11026,11 +11026,11 @@ no ip igmp snooping vlan 25 proxy
 #### IP Router Multicast Summary
 
 - Counters rate period decay is set for 300 seconds
-- Routing for IPv4 multicast is enabled.
-- Routing for IPv6 multicast is enabled.
-- Multipathing deterministically by selecting the same upstream router.
-- IPv4 software forwarding is by the Software Forwarding Engine (SFE)
-- IPv6 software forwarding is by the Software Forwarding Engine (SFE)
+- IPv4 Multicast Routing is enabled.
+- IPv6 Multicast Routing is enabled.
+- Multipathing operates deterministically by selecting the same upstream router.
+- IPv4 software forwarding is handled by the Software Forwarding Engine (SFE).
+- IPv6 software forwarding is handled by the Software Forwarding Engine (SFE).
 
 #### IP Router Multicast RPF Routes
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11027,8 +11027,10 @@ no ip igmp snooping vlan 25 proxy
 
 - Counters rate period decay is set for 300 seconds
 - Routing for IPv4 multicast is enabled.
+- Routing for IPv6 multicast is enabled.
 - Multipathing deterministically by selecting the same upstream router.
-- Software forwarding by the Software Forwarding Engine (SFE)
+- IPv4 software forwarding is by the Software Forwarding Engine (SFE)
+- IPv6 software forwarding is by the Software Forwarding Engine (SFE)
 
 #### IP Router Multicast RPF Routes
 
@@ -11063,6 +11065,8 @@ router multicast
    !
    ipv6
       activity polling-interval 20
+      routing
+      software-forwarding sfe
    !
    vrf MCAST_VRF1
       ipv4

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1438,7 +1438,7 @@ no ip igmp snooping querier
 #### IP Router Multicast Summary
 
 - Multipathing deterministically by selecting the same-colored upstream routers.
-- Software forwarding by the Linux kernel
+- IPv4 software forwarding is by the Linux kernel
 
 #### Router Multicast Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1437,8 +1437,8 @@ no ip igmp snooping querier
 
 #### IP Router Multicast Summary
 
-- Multipathing deterministically by selecting the same-colored upstream routers.
-- IPv4 software forwarding is by the Linux kernel
+- Multipathing operates deterministically by selecting the same-colored upstream routers.
+- IPv4 software forwarding is handled by the Linux kernel.
 
 #### Router Multicast Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host3.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host3.md
@@ -408,7 +408,7 @@ mpls rsvp
 
 #### IP Router Multicast Summary
 
-- Multipathing via ECMP.
+- Multipathing operates via ECMP.
 
 #### Router Multicast Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6934,6 +6934,8 @@ router multicast
    !
    ipv6
       activity polling-interval 20
+      routing
+      software-forwarding sfe
    !
    vrf MCAST_VRF1
       ipv4

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-multicast.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-multicast.yml
@@ -22,6 +22,8 @@ router_multicast:
     software_forwarding: sfe
   ipv6:
     activity_polling_interval: 20
+    routing: true
+    software_forwarding: sfe
   vrfs:
     - name: MCAST_VRF1
       ipv4:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-multicast.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-multicast.md
@@ -23,6 +23,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for this route. |
     | [<samp>&nbsp;&nbsp;ipv6</samp>](## "router_multicast.ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;activity_polling_interval</samp>](## "router_multicast.ipv6.activity_polling_interval") | Integer |  |  | Min: 1<br>Max: 60 | MFIB entry activity polling interval. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.ipv6.routing") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;software_forwarding</samp>](## "router_multicast.ipv6.software_forwarding") | String |  |  | Valid Values:<br>- <code>kernel</code><br>- <code>sfe</code> |  |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_multicast.vrfs.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  |  |
@@ -59,6 +61,8 @@
 
         # MFIB entry activity polling interval.
         activity_polling_interval: <int; 1-60>
+        routing: <bool>
+        software_forwarding: <str; "kernel" | "sfe">
       vrfs:
         - name: <str; required; unique>
           ipv4:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
@@ -22,7 +22,7 @@
 {%     if router_multicast.ipv4.multipath is arista.avd.defined('deterministic color') %}
 - Multipathing operates deterministically by selecting the same-colored upstream routers.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic router-id') %}
-- Multipathing deterministically by selecting the same upstream router.
+- Multipathing operates deterministically by selecting the same upstream router.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('none') %}
 - Multipathing disabled.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic') %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
@@ -16,6 +16,9 @@
 {%     if router_multicast.ipv4.routing is arista.avd.defined(true) %}
 - Routing for IPv4 multicast is enabled.
 {%     endif %}
+{%     if router_multicast.ipv6.routing is arista.avd.defined(true) %}
+- Routing for IPv6 multicast is enabled.
+{%     endif %}
 {%     if router_multicast.ipv4.multipath is arista.avd.defined('deterministic color') %}
 - Multipathing deterministically by selecting the same-colored upstream routers.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic router-id') %}
@@ -26,9 +29,14 @@
 - Multipathing via ECMP.
 {%     endif %}
 {%     if router_multicast.ipv4.software_forwarding is arista.avd.defined('kernel') %}
-- Software forwarding by the Linux kernel
+- IPv4 software forwarding is by the Linux kernel
 {%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
-- Software forwarding by the Software Forwarding Engine (SFE)
+- IPv4 software forwarding is by the Software Forwarding Engine (SFE)
+{%     endif %}
+{%     if router_multicast.ipv6.software_forwarding is arista.avd.defined('kernel') %}
+- IPv6 software forwarding is by the Linux kernel
+{%     elif router_multicast.ipv6.software_forwarding is arista.avd.defined('sfe') %}
+- IPv6 software forwarding is by the Software Forwarding Engine (SFE)
 {%     endif %}
 {%     if router_multicast.ipv4.rpf.routes is arista.avd.defined %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-multicast.j2
@@ -14,29 +14,29 @@
 - Counters rate period decay is set for {{ router_multicast.ipv4.counters.rate_period_decay }} seconds
 {%     endif %}
 {%     if router_multicast.ipv4.routing is arista.avd.defined(true) %}
-- Routing for IPv4 multicast is enabled.
+- IPv4 Multicast Routing is enabled.
 {%     endif %}
 {%     if router_multicast.ipv6.routing is arista.avd.defined(true) %}
-- Routing for IPv6 multicast is enabled.
+- IPv6 Multicast Routing is enabled.
 {%     endif %}
 {%     if router_multicast.ipv4.multipath is arista.avd.defined('deterministic color') %}
-- Multipathing deterministically by selecting the same-colored upstream routers.
+- Multipathing operates deterministically by selecting the same-colored upstream routers.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic router-id') %}
 - Multipathing deterministically by selecting the same upstream router.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('none') %}
 - Multipathing disabled.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic') %}
-- Multipathing via ECMP.
+- Multipathing operates via ECMP.
 {%     endif %}
 {%     if router_multicast.ipv4.software_forwarding is arista.avd.defined('kernel') %}
-- IPv4 software forwarding is by the Linux kernel
+- IPv4 software forwarding is handled by the Linux kernel.
 {%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
-- IPv4 software forwarding is by the Software Forwarding Engine (SFE)
+- IPv4 software forwarding is handled by the Software Forwarding Engine (SFE).
 {%     endif %}
 {%     if router_multicast.ipv6.software_forwarding is arista.avd.defined('kernel') %}
-- IPv6 software forwarding is by the Linux kernel
+- IPv6 software forwarding is handled by the Linux kernel.
 {%     elif router_multicast.ipv6.software_forwarding is arista.avd.defined('sfe') %}
-- IPv6 software forwarding is by the Software Forwarding Engine (SFE)
+- IPv6 software forwarding is handled by the Software Forwarding Engine (SFE).
 {%     endif %}
 {%     if router_multicast.ipv4.rpf.routes is arista.avd.defined %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-multicast.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-multicast.j2
@@ -41,6 +41,12 @@ router multicast
 {%         if router_multicast.ipv6.activity_polling_interval is arista.avd.defined %}
       activity polling-interval {{ router_multicast.ipv6.activity_polling_interval }}
 {%         endif %}
+{%         if router_multicast.ipv6.routing is arista.avd.defined(true) %}
+      routing
+{%         endif %}
+{%         if router_multicast.ipv6.software_forwarding is arista.avd.defined %}
+      software-forwarding {{ router_multicast.ipv4.software_forwarding }}
+{%         endif %}
 {%     endif %}
 {%     for vrf in router_multicast.vrfs | arista.avd.natural_sort('name', ignore_case=false) %}
    !

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -58982,13 +58982,22 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class Ipv6(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"activity_polling_interval": {"type": int}}
+            SoftwareForwarding: TypeAlias = Literal["kernel", "sfe"]
+            _fields: ClassVar[dict] = {"activity_polling_interval": {"type": int}, "routing": {"type": bool}, "software_forwarding": {"type": str}}
             activity_polling_interval: int | None
             """MFIB entry activity polling interval."""
+            routing: bool | None
+            software_forwarding: SoftwareForwarding | None
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, activity_polling_interval: int | None | UndefinedType = Undefined) -> None:
+                def __init__(
+                    self,
+                    *,
+                    activity_polling_interval: int | None | UndefinedType = Undefined,
+                    routing: bool | None | UndefinedType = Undefined,
+                    software_forwarding: SoftwareForwarding | None | UndefinedType = Undefined,
+                ) -> None:
                     """
                     Ipv6.
 
@@ -58997,6 +59006,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         activity_polling_interval: MFIB entry activity polling interval.
+                        routing: routing
+                        software_forwarding: software_forwarding
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -21700,6 +21700,13 @@ keys:
             min: 1
             max: 60
             description: MFIB entry activity polling interval.
+          routing:
+            type: bool
+          software_forwarding:
+            type: str
+            valid_values:
+            - kernel
+            - sfe
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_multicast.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_multicast.schema.yml
@@ -76,6 +76,11 @@ keys:
             min: 1
             max: 60
             description: MFIB entry activity polling interval.
+          routing:
+            type: bool
+          software_forwarding:
+            type: str
+            valid_values: ["kernel", "sfe"]
       vrfs:
         type: list
         primary_key: name


### PR DESCRIPTION
## Change Summary
Add support for SFE for IPv6, as well as enabling multicast routing for IPv6

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add support for enabling routing under IPv6, as well as enabling SFE.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
