### PR TITLE
CI: Add support to test Python 3.14

### DIFF
--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         container_name: [base]
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python_version: "3.11"
             container_tags: latest

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         container_name: [dev]
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python_version: "3.11"
             container_tags: latest

--- a/.github/workflows/container_build_fix.yml
+++ b/.github/workflows/container_build_fix.yml
@@ -19,7 +19,7 @@ name: Manual container build
         type: choice
         required: true
         description: "select Python version"
-        options: ["3.10", "3.11", "3.12", "3.13"]
+        options: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         default: "3.11"
       github_tag:
         type: string

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         container_name: [universal]
-        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python_version: "3.11"
             container_tags: latest

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
 ]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,8 @@ sonar.python.version=\
     3.10,\
     3.11,\
     3.12,\
-    3.13
+    3.13,\
+    3.14
 
 sonar.python.coverage.reportPaths=\
     coverage.xml,\

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ env_list =
     py311
     py312
     py313
+    py314
     coverage
     report
 
@@ -16,6 +17,7 @@ python =
   3.11: coverage
   3.12: py312
   3.13: py313
+  3.14: py314
 
 [testenv]
 # We have multiple packages so we skip installing them and install them as editables in deps instead


### PR DESCRIPTION
## Change Summary

- [x] Updating tox, sonarcloud & pyproject.toml with Python 3.14
- [x] Build containers with Python 3.14

Leveraged PR #4651 as a reference


