### PR TITLE
Bump: grpclib>=0.4.8

### DIFF
--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -7,7 +7,7 @@ aristaproto>=0.1.1
 cryptography>=43.0.0
 deepmerge>=1.1.0
 distlib>=0.3.9
-grpclib==0.4.9
+grpclib>=0.4.8
 jinja2>=3.0
 netaddr>=0.7.19
 pyavd==6.0.0

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "aristaproto>=0.1.1",
     "cryptography>=43.0.0",
     "deepmerge>=1.1.0",
-    # pinned grpclib since we patch the connection code to get proxy support
-    "grpclib==0.4.9",
+    # we patch the connection code in grpclib to get proxy support, so we need to carefully monitor and test new versions
+    "grpclib>=0.4.8",
     "jinja2>=3.0",
     "pyavd-utils==0.0.2",
     "python-socks[asyncio]>=2.7.2",


### PR DESCRIPTION
## Change Summary

Bump: grpclib>=0.4.8 to satisfy Ansible Certification requirements.

Note: We patch the connection code in grpclib to get proxy support, so we need to carefully monitor and test new versions in the internal CI pipeline.

## How to test

Review internal CI test results: https://github.com/aristanetworks/avd-internal/actions/runs/22314581187

