### PR TITLE
CI: Setup codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,9 +25,6 @@ flags:
   pyavd:
     paths:
       - python-avd/pyavd/
-  ansible-plugins:
-    paths:
-      - ansible_collections/arista/avd/plugins/
   ansible-test-units:
     paths:
       - ansible_collections/arista/avd/plugins/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -55,9 +55,5 @@ ignore:
   - "python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py"
   - "python-avd/pyavd/_cv/api/**/*"
 
-  # Compiled templates (generated code)
-  - "python-avd/pyavd/_eos_designs/j2templates/compiled_templates/**/*"
-  - "python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/**/*"
-
   # Coverage report files
   - "python-avd/**/coverage.xml"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,57 @@
+---
+# CodeCov Configuration for AVD
+# Reference: https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        paths:
+          - "python-avd/pyavd/"
+          - "ansible_collections/arista/avd/plugins/"
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+
+flags:
+  pyavd:
+    paths:
+      - python-avd/pyavd/
+  ansible-plugins:
+    paths:
+      - ansible_collections/arista/avd/plugins/
+  ansible-test-units:
+    paths:
+      - ansible_collections/arista/avd/plugins/
+  ansible-test-integration:
+    paths:
+      - ansible_collections/arista/avd/plugins/
+
+ignore:
+  # Test directories
+  - "python-avd/tests/**/*"
+  - "ansible_collections/arista/avd/tests/**/*"
+  - "ansible_collections/arista/avd/extensions/molecule/**/*"
+
+  # Documentation
+  - "docs/**/*"
+  - "ansible_collections/arista/avd/docs/**/*"
+
+  # Schema tools (build-time only)
+  - "python-avd/schema_tools/**/*"
+  - "python-avd/scripts/**/*"
+
+  # Examples
+  - "ansible_collections/arista/avd/examples/**/*"
+
+  # Compiled templates (generated code)
+  - "python-avd/pyavd/_eos_designs/j2templates/compiled_templates/**/*"
+  - "python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/**/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,8 +9,7 @@ coverage:
         target: auto
         threshold: 0.5%
         paths:
-          - "python-avd/pyavd/"
-          - "python-avd/schema_tools/"
+          - "python-avd"
           - "ansible_collections/arista/avd/plugins/"
     patch:
       default:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,12 +43,6 @@ ignore:
   - "docs/**/*"
   - "ansible_collections/arista/avd/docs/**/*"
 
-<<<<<<< HEAD
-=======
-
-
-
->>>>>>> b39eaae4d (CI: Remove scripts and compiled templates from Codecov ignore list)
   # Examples
   - "ansible_collections/arista/avd/examples/**/*"
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -50,6 +50,15 @@ ignore:
   # Examples
   - "ansible_collections/arista/avd/examples/**/*"
 
+  # Generated code
+  - "python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py"
+  - "python-avd/pyavd/_eos_designs/schema/__init__.py"
+  - "python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py"
+  - "python-avd/pyavd/_cv/api/**/*"
+
   # Compiled templates (generated code)
   - "python-avd/pyavd/_eos_designs/j2templates/compiled_templates/**/*"
   - "python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/**/*"
+
+  # Coverage report files
+  - "python-avd/**/coverage.xml"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -46,7 +46,8 @@ ignore:
   # Examples
   - "ansible_collections/arista/avd/examples/**/*"
 
-  # Generated code
+  # Ignore checked-in generated code
+  # Unchecked files are not supported by codecov
   - "python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py"
   - "python-avd/pyavd/_eos_designs/schema/__init__.py"
   - "python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,9 +43,6 @@ ignore:
   - "docs/**/*"
   - "ansible_collections/arista/avd/docs/**/*"
 
-  # Scripts (build-time only)
-  - "python-avd/scripts/**/*"
-
   # Examples
   - "ansible_collections/arista/avd/examples/**/*"
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,7 @@ coverage:
         threshold: 0.5%
         paths:
           - "python-avd/pyavd/"
+          - "python-avd/schema_tools/"
           - "ansible_collections/arista/avd/plugins/"
     patch:
       default:
@@ -25,6 +26,7 @@ flags:
   pyavd:
     paths:
       - python-avd/pyavd/
+      - python-avd/schema_tools/
   ansible-test-units:
     paths:
       - ansible_collections/arista/avd/plugins/
@@ -42,8 +44,7 @@ ignore:
   - "docs/**/*"
   - "ansible_collections/arista/avd/docs/**/*"
 
-  # Schema tools (build-time only)
-  - "python-avd/schema_tools/**/*"
+  # Scripts (build-time only)
   - "python-avd/scripts/**/*"
 
   # Examples

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,6 +43,12 @@ ignore:
   - "docs/**/*"
   - "ansible_collections/arista/avd/docs/**/*"
 
+<<<<<<< HEAD
+=======
+
+
+
+>>>>>>> b39eaae4d (CI: Remove scripts and compiled templates from Codecov ignore list)
   # Examples
   - "ansible_collections/arista/avd/examples/**/*"
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,6 +34,20 @@ jobs:
         with:
           name: ansible-test-integration-coverage
 
+      - name: Download eos_designs compiled templates from pytest
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: pytest-eos-designs-compiled-templates
+          path: python-avd/pyavd/_eos_designs/j2templates/compiled_templates/
+
+      - name: Download eos_cli_config_gen compiled templates from pytest
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: pytest-eos-cli-config-gen-compiled-templates
+          path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
+
       - name: Upload pytest coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -54,6 +54,10 @@ jobs:
           ls -la python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/ || echo "Directory not found"
           echo "=== Coverage files ==="
           find . -name "*.xml" -type f
+          echo "=== Check if coverage.xml contains compiled templates ==="
+          grep -c "compiled_templates" coverage.xml || echo "No compiled_templates references found in coverage.xml"
+          echo "=== Sample of compiled template references in coverage.xml ==="
+          grep "compiled_templates" coverage.xml | head -5 || echo "No references found"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,14 +34,26 @@ jobs:
         with:
           name: ansible-test-integration-coverage
 
-      - name: Upload results to Codecov
+      - name: Upload pytest coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           use_oidc: true
-          fail_ci_if_error: true
-          flags: >-
-            pyavd,ansible-plugins,ansible-test-units,ansible-test-integration
-          files: >-
-            ./coverage.xml,
-            ./ansible_collections/arista/avd/units-coverage.xml,
-            ./ansible_collections/arista/avd/integration-coverage.xml
+          fail_ci_if_error: false
+          flags: pyavd
+          files: ./coverage.xml
+
+      - name: Upload ansible-test units coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          fail_ci_if_error: false
+          flags: ansible-test-units
+          files: ./ansible_collections/arista/avd/units-coverage.xml
+
+      - name: Upload ansible-test integration coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          fail_ci_if_error: false
+          flags: ansible-test-integration
+          files: ./ansible_collections/arista/avd/integration-coverage.xml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,21 +43,8 @@ jobs:
       - name: Download eos_cli_config_gen compiled templates from pytest
         uses: actions/download-artifact@v7
         with:
-          name: pytest-eos-cli-config-gen-compiled-templates
+          name: pytest-eos-cli-config-gen-compiled_templates
           path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
-
-      - name: Debug - List compiled templates
-        run: |
-          echo "=== EOS Designs Compiled Templates ==="
-          ls -la python-avd/pyavd/_eos_designs/j2templates/compiled_templates/ || echo "Directory not found"
-          echo "=== EOS CLI Config Gen Compiled Templates ==="
-          ls -la python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/ || echo "Directory not found"
-          echo "=== Coverage files ==="
-          find . -name "*.xml" -type f
-          echo "=== Check if coverage.xml contains compiled templates ==="
-          grep -c "compiled_templates" coverage.xml || echo "No compiled_templates references found in coverage.xml"
-          echo "=== Sample of compiled template references in coverage.xml ==="
-          grep "compiled_templates" coverage.xml | head -5 || echo "No references found"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Download eos_cli_config_gen compiled templates from pytest
         uses: actions/download-artifact@v7
         with:
-          name: pytest-eos-cli-config-gen-compiled_templates
+          name: pytest-eos-cli-config-gen-compiled-templates
           path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,14 +35,12 @@ jobs:
           name: ansible-test-integration-coverage
 
       - name: Download eos_designs compiled templates from pytest
-        continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: pytest-eos-designs-compiled-templates
           path: python-avd/pyavd/_eos_designs/j2templates/compiled_templates/
 
       - name: Download eos_cli_config_gen compiled templates from pytest
-        continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: pytest-eos-cli-config-gen-compiled-templates

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,35 @@
+---
+name: Publish coverage to CodeCov
+"on":
+  workflow_run:
+
+jobs:
+  codecov:
+    name: Upload coverage to CodeCov
+    if: github.repository == 'aristanetworks/avd'
+    runs-on: ubuntu-latest
+    # These permissions are mandatory for OIDC to work
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Download coverage from unit tests
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: pytest-coverage
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        with:
+          use_oidc: true
+          fail_ci_if_error: true
+          flags: >-
+            pyavd,ansible-plugins,ansible-test-units,ansible-test-integration
+          files: >-
+            ./coverage.xml,
+            ./ansible_collections/arista/avd/units-coverage.xml,
+            ./ansible_collections/arista/avd/integration-coverage.xml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish coverage to CodeCov
 "on":
-  workflow_run:
+  workflow_call:
 
 jobs:
   codecov:
@@ -16,11 +16,23 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Download coverage from unit tests
+      - name: Download coverage from pytest
         continue-on-error: true
         uses: actions/download-artifact@v7
         with:
           name: pytest-coverage
+
+      - name: Download coverage from ansible-test units
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: ansible-test-units-coverage
+
+      - name: Download coverage from ansible-test integration
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: ansible-test-integration-coverage
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,26 +48,8 @@ jobs:
           name: pytest-eos-cli-config-gen-compiled-templates
           path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
 
-      - name: Upload pytest coverage to Codecov
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           use_oidc: true
           fail_ci_if_error: false
-          flags: pyavd
-          files: ./coverage.xml
-
-      - name: Upload ansible-test units coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-        with:
-          use_oidc: true
-          fail_ci_if_error: false
-          flags: ansible-test-units
-          files: ./ansible_collections/arista/avd/units-coverage.xml
-
-      - name: Upload ansible-test integration coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
-        with:
-          use_oidc: true
-          fail_ci_if_error: false
-          flags: ansible-test-integration
-          files: ./ansible_collections/arista/avd/integration-coverage.xml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,17 +34,21 @@ jobs:
         with:
           name: ansible-test-integration-coverage
 
-      - name: Download eos_designs compiled templates from pytest
-        uses: actions/download-artifact@v7
-        with:
-          name: pytest-eos-designs-compiled-templates
-          path: python-avd/pyavd/_eos_designs/j2templates/compiled_templates/
+      ######################################################################
+      # This section is commented out as it is not parsing the compiled templates,
+      # only files included in the repository are parsed, codecov limitation.
+      ######################################################################
+      # - name: Download eos_designs compiled templates from pytest
+      #   uses: actions/download-artifact@v7
+      #   with:
+      #     name: pytest-eos-designs-compiled-templates
+      #     path: python-avd/pyavd/_eos_designs/j2templates/compiled_templates/
 
-      - name: Download eos_cli_config_gen compiled templates from pytest
-        uses: actions/download-artifact@v7
-        with:
-          name: pytest-eos-cli-config-gen-compiled-templates
-          path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
+      # - name: Download eos_cli_config_gen compiled templates from pytest
+      #   uses: actions/download-artifact@v7
+      #   with:
+      #     name: pytest-eos-cli-config-gen-compiled-templates
+      #     path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,6 +46,15 @@ jobs:
           name: pytest-eos-cli-config-gen-compiled-templates
           path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
 
+      - name: Debug - List compiled templates
+        run: |
+          echo "=== EOS Designs Compiled Templates ==="
+          ls -la python-avd/pyavd/_eos_designs/j2templates/compiled_templates/ || echo "Directory not found"
+          echo "=== EOS CLI Config Gen Compiled Templates ==="
+          ls -la python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/ || echo "Directory not found"
+          echo "=== Coverage files ==="
+          find . -name "*.xml" -type f
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,22 +34,6 @@ jobs:
         with:
           name: ansible-test-integration-coverage
 
-      ######################################################################
-      # This section is commented out as it is not parsing the compiled templates,
-      # only files included in the repository are parsed, codecov limitation.
-      ######################################################################
-      # - name: Download eos_designs compiled templates from pytest
-      #   uses: actions/download-artifact@v7
-      #   with:
-      #     name: pytest-eos-designs-compiled-templates
-      #     path: python-avd/pyavd/_eos_designs/j2templates/compiled_templates/
-
-      # - name: Download eos_cli_config_gen compiled templates from pytest
-      #   uses: actions/download-artifact@v7
-      #   with:
-      #     name: pytest-eos-cli-config-gen-compiled-templates
-      #     path: python-avd/pyavd/_eos_cli_config_gen/j2templates/compiled_templates/
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -701,3 +701,12 @@ jobs:
         with:
           name: pytest-coverage
           path: coverage.xml
+
+  codecov:
+    name: Upload coverage to codecov
+    needs:
+      - ansible_test_units
+      - ansible_test_integration
+      - generate_pyavd_coverage_report
+    if: github.repository == 'aristanetworks/avd'
+    uses: ./.github/workflows/codecov.yml


### PR DESCRIPTION
## Change Summary

> [!NOTE]
> as agreed on the maintainer call on Friday 02/27/2026 we will accept to not see the compiuled templates coverage in codecov and still move on with merging this PR once it is ready. We will keep sonar in parallel until we find a way forward.

add codecov workflow and configuration 

## Related Issue(s)

Fixes - Step 1 of [351](https://github.com/aristanetworks/avd-internal/issues/351)

## Component(s) name

CI 

## Proposed changes

Add configuration file 
Add workflow file 

## How to test
With the PR we will be able to run CI and verifiy codecov integration 

## Checklist

### User Checklist

Checklist is in the issue

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
