### PR TITLE
Refactor(eos_designs)!: Disable ip routing for devices which are not underlay routers

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -150,6 +150,8 @@ interface Vlan4091
    mtu 1498
    no autostate
    ip address 10.255.252.14/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -139,6 +139,8 @@ interface Vlan4091
    mtu 1499
    no autostate
    ip address 10.255.252.15/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
@@ -155,6 +155,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.16/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
@@ -155,6 +155,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.17/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
@@ -92,6 +92,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.116/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
@@ -92,6 +92,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.119/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
@@ -122,6 +122,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.26/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
@@ -122,6 +122,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.27/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
@@ -156,6 +156,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.30/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
@@ -156,6 +156,8 @@ interface Vlan4091
    mtu 1500
    no autostate
    ip address 10.255.252.31/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF7A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF7A.cfg
@@ -126,6 +126,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.124/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
@@ -145,6 +145,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
@@ -80,6 +80,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
@@ -83,6 +83,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.201.201/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
@@ -27,6 +27,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.254.254/23
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
@@ -27,6 +27,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.254.255/23
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER3.cfg
@@ -27,6 +27,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.254.253/23
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0A.cfg
@@ -41,6 +41,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.0/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0B.cfg
@@ -87,6 +87,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.1/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1A.cfg
@@ -67,6 +67,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.4/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1B.cfg
@@ -54,6 +54,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.5/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2A.cfg
@@ -59,6 +59,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.10/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2B.cfg
@@ -59,6 +59,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.10.255.11/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-MLEAF1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/SL-MLEAF1.cfg
@@ -23,6 +23,8 @@ interface Ethernet16
    description L2_SL-LEAF1A_Ethernet28
    no shutdown
    channel-group 16 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.cfg
@@ -19,6 +19,8 @@ interface Management1
    ip address 192.168.201.202/24
    ipv6 enable
    ipv6 address 2001:db8::105/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.201.254

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
@@ -29,6 +29,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
@@ -73,6 +73,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.252.0/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
@@ -73,6 +73,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.252.1/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.cfg
@@ -35,6 +35,8 @@ interface Ethernet2
 interface Ethernet10
    no shutdown
    switchport
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-1.cfg
@@ -88,6 +88,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf default source-interface Vlan123

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-2.cfg
@@ -55,6 +55,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT
    ip address 192.168.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf INBAND_MGMT source-interface Vlan4092

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-3.cfg
@@ -65,6 +65,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT
    ip address 192.168.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Ma1/1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -400,6 +400,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.1.2
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints_no_network_services.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints_no_network_services.cfg
@@ -25,6 +25,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/custom-structured-configuration.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/custom-structured-configuration.cfg
@@ -43,6 +43,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.100.10/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-settings.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-settings.cfg
@@ -58,6 +58,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT_VRF
    ip address 172.17.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ntp server 10.10.10.1 prefer

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_hostvars.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_hostvars.cfg
@@ -14,6 +14,8 @@ service routing protocols model multi-agent
 hostname default_interface_mtu_hostvars
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/devices-l2leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/devices-l2leaf1.cfg
@@ -34,6 +34,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 172.16.1.151/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-1.cfg
@@ -37,6 +37,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-2.cfg
@@ -30,6 +30,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT
    ip address 192.168.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-3.cfg
@@ -37,6 +37,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT
    ip address 192.168.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-1.cfg
@@ -22,6 +22,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-2.cfg
@@ -37,6 +37,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-3.cfg
@@ -21,6 +21,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-4.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-4.cfg
@@ -25,6 +25,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
@@ -24,6 +24,8 @@ interface Ethernet1
    switchport trunk allowed vlan 1-2
    switchport mode trunk
    switchport
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf1.cfg
@@ -58,6 +58,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.4/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf2.cfg
@@ -58,6 +58,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.5/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf3.cfg
@@ -68,6 +68,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.6/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf4.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf4.cfg
@@ -67,6 +67,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.6/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
@@ -22,6 +22,8 @@ service routing protocols model multi-agent
 hostname hardware_counters
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
@@ -14,6 +14,8 @@ vrf instance MGMT
 !
 interface Ethernet1
    switchport
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-ips.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-ips.cfg
@@ -45,6 +45,8 @@ interface Vlan105
    ip address 192.168.105.22/24
    ipv6 enable
    ipv6 address 2a00:105::123/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 192.168.105.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-subnets.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-subnets.cfg
@@ -45,6 +45,8 @@ interface Vlan104
    ip address 192.168.104.7/24
    ipv6 enable
    ipv6 address 2a00:104::7/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 192.168.104.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ip.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ip.cfg
@@ -46,6 +46,8 @@ interface Vlan103
    mtu 1500
    vrf INBANDMGMT
    ip address 192.168.103.22/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ntp local-interface vrf INBANDMGMT Vlan103

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
@@ -45,6 +45,8 @@ interface Vlan107
    vrf INBANDMGMT
    ipv6 enable
    ipv6 address 2a00:107::a/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ipv6 route vrf INBANDMGMT ::/0 2a00:107::1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only.cfg
@@ -44,6 +44,8 @@ interface Vlan106
    mtu 1500
    ipv6 enable
    ipv6 address 2a00:106::9/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ipv6 route ::/0 2a00:106::1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-a.cfg
@@ -156,6 +156,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 100.64.0.200/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-b.cfg
@@ -156,6 +156,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 100.64.0.201/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-per-interface-mtu-false.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-per-interface-mtu-false.cfg
@@ -25,6 +25,8 @@ interface Vlan108
    description Inband Management
    no shutdown
    ip address 192.168.103.22/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ntp local-interface Vlan108

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet-vrf.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet-vrf.cfg
@@ -46,6 +46,8 @@ interface Vlan102
    mtu 1500
    vrf INBANDMGMT
    ip address 192.168.102.5/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf INBANDMGMT 0.0.0.0/0 192.168.102.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet.cfg
@@ -43,6 +43,8 @@ interface Vlan101
    no shutdown
    mtu 1500
    ip address 192.168.101.7/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 192.168.101.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -154,6 +154,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 1.1.1.2
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
@@ -17,6 +17,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 1.1.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.254

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
@@ -19,6 +19,8 @@ interface Management1
    ip address 192.168.200.105
    ipv6 enable
    ipv6 address 0200::105/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 10.0.10.0/24 192.168.200.5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -154,6 +154,8 @@ interface MY_INTERFACE_FABRIC
    no shutdown
    vrf MGMT
    ip address 1.1.1.2
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -159,6 +159,8 @@ interface MY_INTERFACE_HOST
 !
 hardware tcam
    system profile vxlan-routing
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
@@ -18,6 +18,8 @@ interface Management1
    vrf MGMT
    ipv6 enable
    ipv6 address 0200::105/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ipv6 route vrf MGMT ::/0 0200::2

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -159,6 +159,8 @@ interface Management0
 !
 hardware tcam
    system profile vxlan-routing
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -639,6 +639,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.252.1/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 monitor session DMF source Ethernet14 both

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -602,6 +602,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.252.0/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
@@ -17,6 +17,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.106
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
@@ -11,6 +11,8 @@ service routing protocols model multi-agent
 hostname no_mgmt_interface
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-1.cfg
@@ -17,6 +17,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ntp authentication-key 1 sha1 7 06071D285F5A08

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-2.cfg
@@ -23,6 +23,8 @@ interface Vlan4092
    mtu 1500
    vrf INBAND_MGMT
    ip address 192.168.1.2/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ntp local-interface vrf INBAND_MGMT Vlan4092

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/only-connected-endpoints.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/only-connected-endpoints.cfg
@@ -128,6 +128,8 @@ interface Management1
    vrf MGMT
    ip address 192.168.1.2
 !
+no ip routing
+!
 ip radius vrf MGMT source-interface Management1
 !
 dot1x system-auth-control

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf1-ptp-disabled.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf1-ptp-disabled.cfg
@@ -34,6 +34,8 @@ interface Ethernet2
    description L2_ptp-tests-leaf2_Ethernet11
    no shutdown
    channel-group 1 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.cfg
@@ -47,6 +47,8 @@ interface Ethernet2
    description L2_ptp-tests-leaf2_Ethernet14
    no shutdown
    channel-group 1 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled.cfg
@@ -53,6 +53,8 @@ interface Ethernet2
    description L2_ptp-tests-leaf2_Ethernet12
    no shutdown
    channel-group 1 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/relaxed-structured-config-validation.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/relaxed-structured-config-validation.cfg
@@ -13,6 +13,8 @@ hostname relaxed-structured-config-validation
 vrf instance MGMT
 !
 aaa accounting exec console start-stop group node_group
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-settings-1.cfg
@@ -54,6 +54,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.4/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-settings-2.cfg
@@ -54,6 +54,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.4/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
@@ -56,6 +56,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.4/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
@@ -56,6 +56,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.254.254.5/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.254.254.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-hostname-and-ip-inband.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-hostname-and-ip-inband.cfg
@@ -16,6 +16,8 @@ snmp-server location EOS_DESIGNS_UNIT_TESTS snmp-autogen-engineid-hostname-and-i
 snmp-server user usertest-auth-priv usergroup v3 localized 07459749db8910d2ea1447c20595b70729534f97 auth sha d035999725c2ae5776a5c5b685853ecc6503739d priv aes192 7a3e71ab96695ec38d1f1019163797d44bd8f80aa53be88a
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-hostname-ip-oob.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-hostname-ip-oob.cfg
@@ -22,6 +22,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.10/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-inband.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-inband.cfg
@@ -22,6 +22,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 192.168.0.10/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-oob.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-oob.cfg
@@ -19,6 +19,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.0.10/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-inband-ip.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-inband-ip.cfg
@@ -22,6 +22,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 192.168.0.10/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-oob-ip.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-oob-ip.cfg
@@ -21,6 +21,8 @@ interface Management1
    ip address 192.168.0.10/24
    ipv6 enable
    ipv6 address 2001:db8::dead:beef:cafe/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-oob-ipv6.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-oob-ipv6.cfg
@@ -20,6 +20,8 @@ interface Management1
    vrf MGMT
    ipv6 enable
    ipv6 address 2001:db8::dead:beef:cafe/64
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-specific-ip.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-hostname-specific-ip.cfg
@@ -13,6 +13,8 @@ hostname snmp-autogen-engineid-rfc3411-hostname-specific-ip
 snmp-server engineID local 8000757105031afc850e1e7d5bfbdeacc98b866404a0526c03
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-type3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-autogen-engineid-rfc3411-type3.cfg
@@ -14,6 +14,8 @@ snmp-server engineID local 8000757103424242424242
 snmp-server user usertest-auth-priv usergroup v3 localized 8000757103424242424242 auth sha c7d815463b2fd77c87201bc51ae77b93fcf4ac4f priv aes192 a1391df7a8ea377cbe6ccc7537ed6f1e1905bbe38f69eaac
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
@@ -40,6 +40,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 10.10.10.43/26
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 10.10.10.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
@@ -32,6 +32,8 @@ interface Vlan123
    no shutdown
    mtu 1500
    ip address 192.168.0.1/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-system-mac-engineid-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-system-mac-engineid-1.cfg
@@ -19,6 +19,8 @@ snmp-server user usertest-no-auth-no-priv usergroup v3
 snmp-server user usertest-v2c usergroup v2c
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-system-mac-engineid-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/snmp-system-mac-engineid-2.cfg
@@ -16,6 +16,8 @@ snmp-server location CUSTOM LOCATION STRING EOS_DESIGNS_UNIT_TESTS snmp-system-m
 snmp-server user usertest-auth-priv usergroup v3 localized f5717f1234567890ab00 auth sha 70aa970bd9af7f0974d6dc42217b8dc1b92926e5 priv aes192 95943c2756fdbb26473d26269ce768c8bef9878ae11ecac6
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/source-interfaces-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/source-interfaces-1.cfg
@@ -26,6 +26,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 10.20.30.40/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route 0.0.0.0/0 10.20.30.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
@@ -27,6 +27,8 @@ interface Vlan4092
    vrf INBANDMGMT
    ip address 10.20.30.40/24
 !
+no ip routing
+!
 ip route vrf INBANDMGMT 0.0.0.0/0 10.20.30.1
 !
 ip http client local-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
@@ -41,6 +41,8 @@ vlan 23
    name PRIORITY8192
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
@@ -17,6 +17,8 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 10.10.10.43/26
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 10.10.10.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
@@ -20,6 +20,8 @@ interface Vlan123
    no shutdown
    mtu 1500
    ip address 192.168.0.1/24
+!
+no ip routing
 no ip routing vrf MGMT
 !
 management ssh

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-3.cfg
@@ -11,6 +11,8 @@ service routing protocols model multi-agent
 hostname ssh-settings-3
 !
 vrf instance MGMT
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 10.10.10.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
@@ -125,6 +125,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.248.0/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
@@ -125,6 +125,8 @@ interface Vlan4094
    mtu 9214
    no autostate
    ip address 10.255.248.1/31
+!
+no ip routing
 no ip routing vrf MGMT
 !
 mlag configuration

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
@@ -46,6 +46,8 @@ interface Ethernet12
    switchport trunk group TG_200
    switchport trunk group TG_NOT_MATCHING_ANY_VLANS
    switchport
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
@@ -48,6 +48,8 @@ interface Ethernet12
    switchport trunk group TG_200
    switchport trunk group TG_NOT_MATCHING_ANY_VLANS
    switchport
+!
+no ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -31,6 +31,8 @@ interface Ethernet2
    description L2_uplink-native-vlan-parent_Ethernet2
    no shutdown
    channel-group 2 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -27,6 +27,8 @@ interface Ethernet1
    description L2_uplink-native-vlan-parent_Ethernet1
    no shutdown
    channel-group 1 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -44,6 +44,8 @@ interface Ethernet2
    description L2_uplink-native-vlan-child_Ethernet2
    no shutdown
    channel-group 2 mode active
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_l2leaf.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_l2leaf.cfg
@@ -50,6 +50,8 @@ interface Ethernet2
    switchport
    flow tracker sampled FLOW-TRACKER
    spanning-tree portfast
+!
+no ip routing
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -86,6 +86,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -86,6 +86,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -74,6 +74,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -74,6 +74,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -50,6 +50,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -50,6 +50,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -70,6 +70,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -70,6 +70,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
@@ -60,6 +60,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
@@ -60,6 +60,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF7A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF7A.yml
@@ -40,6 +40,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: EVPN-MULTICAST-L2LEAF1A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -17,6 +17,7 @@ ethernet_interfaces:
 hostname: IGMP-QUERIER-L2LEAF1A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -50,6 +50,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 link_tracking_groups:
 - name: l2leaf-server02
   recovery_delay: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.yml
@@ -12,6 +12,7 @@ cvx:
 enable_password:
   disabled: true
 hostname: OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.yml
@@ -12,6 +12,7 @@ cvx:
 enable_password:
   disabled: true
 hostname: OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER3.yml
@@ -12,6 +12,7 @@ cvx:
 enable_password:
   disabled: true
 hostname: OVERLAY_ROUTING_PROTOCOL_CVX_SERVER3
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF0A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF0A.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: SL-LEAF0A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF0B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF0B.yml
@@ -87,6 +87,7 @@ ethernet_interfaces:
 hostname: SL-LEAF0B
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF1A.yml
@@ -47,6 +47,7 @@ ethernet_interfaces:
 hostname: SL-LEAF1A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF1B.yml
@@ -37,6 +37,7 @@ ethernet_interfaces:
 hostname: SL-LEAF1B
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF2A.yml
@@ -47,6 +47,7 @@ ethernet_interfaces:
 hostname: SL-LEAF2A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-LEAF2B.yml
@@ -47,6 +47,7 @@ ethernet_interfaces:
 hostname: SL-LEAF2B
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-MLEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/SL-MLEAF1.yml
@@ -17,6 +17,7 @@ ethernet_interfaces:
 hostname: SL-MLEAF1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: TEST-MGMT-GATEWAY-IN-NODE-GROUP
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 ipv6_static_routes:
 - vrf: MGMT
   prefix: ::/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -17,6 +17,7 @@ ethernet_interfaces:
 hostname: UNDERLAY-MULTICAST-L2LEAF1A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -47,6 +47,7 @@ ethernet_interfaces:
 hostname: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -47,6 +47,7 @@ ethernet_interfaces:
 hostname: UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.yml
@@ -34,6 +34,7 @@ ethernet_interfaces:
 hostname: UPLINK_P2P_VRFS_TESTS_L2LEAF1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-LAB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-1.yml
@@ -179,6 +179,7 @@ ip_radius_source_interfaces:
   vrf: default
 - name: Vlan125
   vrf: MGMT
+ip_routing: false
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
@@ -46,6 +46,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Vlan4092
   vrf: INBAND_MGMT
+ip_routing: false
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
@@ -52,6 +52,7 @@ ip_radius_source_interfaces:
   vrf: INBAND_MGMT
 - name: Ma1/1
   vrf: MGMT
+ip_routing: false
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -527,6 +527,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 link_tracking_groups:
 - name: LT_GROUP1
   recovery_delay: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints_no_network_services.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints_no_network_services.yml
@@ -16,6 +16,7 @@ ethernet_interfaces:
     enabled: true
     mode: trunk
 hostname: connected_endpoints_no_network_services
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/custom-structured-configuration.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/custom-structured-configuration.yml
@@ -22,6 +22,7 @@ enable_password:
   disabled: true
 hostname: custom-structured-configuration
 ip_igmp_snooping: {}
+ip_routing: false
 local_users:
 - name: eos-designs-admin
   disabled: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
@@ -104,6 +104,7 @@ ip_name_server:
     servers:
     - ip_address: 10.10.10.1
       priority: 1
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/default_interface_mtu_hostvars.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/default_interface_mtu_hostvars.yml
@@ -8,6 +8,7 @@ interface_defaults:
   mtu: 1234
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/devices-l2leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/devices-l2leaf1.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: devices-l2leaf1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-1.yml
@@ -38,6 +38,7 @@ ip_name_server:
   - name: other_vrf
     servers:
     - ip_address: 10.10.10.2
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-2.yml
@@ -26,6 +26,7 @@ ip_name_server:
   - name: other_vrf
     servers:
     - ip_address: 10.10.10.2
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-3.yml
@@ -31,6 +31,7 @@ ip_name_server:
   - name: other_vrf
     servers:
     - ip_address: 10.10.10.2
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-1.yml
@@ -25,6 +25,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
@@ -54,6 +54,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-3.yml
@@ -17,6 +17,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-4.yml
@@ -34,6 +34,7 @@ ip_igmp_snooping:
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
@@ -20,6 +20,7 @@ ethernet_interfaces:
 hostname: filter.only_vlans_in_use
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
@@ -42,6 +42,7 @@ flow_tracking:
 hostname: flow-tracking-tests-l2-leaf1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
@@ -42,6 +42,7 @@ flow_tracking:
 hostname: flow-tracking-tests-l2-leaf2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf3.yml
@@ -65,6 +65,7 @@ ip_name_server:
   - name: default
     servers:
     - ip_address: 192.168.200.5
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf4.yml
@@ -64,6 +64,7 @@ ip_name_server:
   - name: default
     servers:
     - ip_address: 192.168.200.5
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/hardware_counters.yml
@@ -36,6 +36,7 @@ hardware_counters:
 hostname: hardware_counters
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ignore-custom-keys-in-data-models.yml
@@ -12,6 +12,7 @@ ethernet_interfaces:
 hostname: ignore-custom-keys-in-data-models
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 ipv6_static_routes:
 - prefix: ::/0
   next_hop: 2a00:105::1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 ipv6_static_routes:
 - prefix: ::/0
   next_hop: 2a00:104::1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ip.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ip.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 ipv6_static_routes:
 - vrf: INBANDMGMT
   prefix: ::/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 ipv6_static_routes:
 - prefix: ::/0
   next_hop: 2a00:106::1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
@@ -192,6 +192,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
@@ -192,6 +192,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-per-interface-mtu-false.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-per-interface-mtu-false.yml
@@ -21,6 +21,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
@@ -42,6 +42,7 @@ ip_name_server:
     servers:
     - ip_address: 1.1.1.1
     - ip_address: 8.8.8.8
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -31,6 +31,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: mgmt_interface_description
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: Custom Management Interface Description

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: mgmt_interface_dualstack
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 ipv6_static_routes:
 - vrf: MGMT
   prefix: 0200:1::/64

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -31,6 +31,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -31,6 +31,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: mgmt_interface_ipv6
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 ipv6_static_routes:
 - vrf: MGMT
   prefix: ::/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -31,6 +31,7 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
+ip_routing: false
 local_users:
 - name: admin
   disabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -893,6 +893,7 @@ ethernet_interfaces:
 hostname: network-ports-tests-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: 720XPM-24Y6

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -878,6 +878,7 @@ ethernet_interfaces:
 hostname: network-ports-tests.1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: 720XPM-48Y6

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_gateway.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: no_mgmt_gateway
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: no_mgmt_interface
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-1.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: ntp-settings-1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-2.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: ntp-settings-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/only-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/only-connected-endpoints.yml
@@ -241,6 +241,7 @@ hostname: only-connected-endpoints
 ip_radius_source_interfaces:
 - name: Management1
   vrf: MGMT
+ip_routing: false
 management_api_http: null
 management_interfaces:
 - name: Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf1-ptp-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf1-ptp-disabled.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: ptp-tests-l2leaf1-ptp-disabled
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-lab

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: ptp-tests-l2leaf2-ptp-enabled-uplink-disabled
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-lab

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: ptp-tests-l2leaf2-ptp-enabled
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   platform: vEOS-lab

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/relaxed-structured-config-validation.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/relaxed-structured-config-validation.yml
@@ -13,6 +13,7 @@ enable_password:
 hostname: relaxed-structured-config-validation
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-settings-1.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: sflow-settings-1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-settings-2.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: sflow-settings-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: sflow-tests-l2-leaf1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: sflow-tests-l2-leaf2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-hostname-and-ip-inband.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-hostname-and-ip-inband.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-hostname-and-ip-inband
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-hostname-ip-oob.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-hostname-ip-oob.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-hostname-ip-oob
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-inband.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-inband.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-default-mgmt-inband
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-oob.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-default-mgmt-oob.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-default-mgmt-oob
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-inband-ip.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-inband-ip.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-inband-ip
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-oob-ip.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-oob-ip.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-oob-ip
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-oob-ipv6.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-oob-ipv6.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-oob-ipv6
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-specific-ip.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-hostname-specific-ip.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-hostname-specific-ip
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-type3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-autogen-engineid-rfc3411-type3.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-autogen-engineid-rfc3411-type3
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   system_mac_address: '42:42:42:42:42:42'

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-settings-1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-settings-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-system-mac-engineid-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-system-mac-engineid-1.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-system-mac-engineid-1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   system_mac_address: '42:42:42:42:42:42'

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-system-mac-engineid-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-system-mac-engineid-2.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: snmp-system-mac-engineid-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   system_mac_address: 12:34:56:78:90:AB

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces-1.yml
@@ -11,6 +11,7 @@ ip_http_client:
     source_interface: Management1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 ip_ssh_client:
   source_interface: Vlan4092
   vrfs:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
@@ -11,6 +11,7 @@ ip_http_client:
     source_interface: Vlan4092
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 ip_ssh_client:
   source_interface: Management1
   vrfs:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/spanning-tree-mode-rapid-pvst.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/spanning-tree-mode-rapid-pvst.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: spanning-tree-mode-rapid-pvst
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: ssh-settings-1
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: ssh-settings-2
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_ssh:
   ip_access_group_in: ACL-SSH-INBAND-MGMT
   idle_timeout: 0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-3.yml
@@ -6,6 +6,7 @@ enable_password:
 hostname: ssh-settings-3
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 management_ssh:
   vrfs:
   - name: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -58,6 +58,7 @@ ethernet_interfaces:
 hostname: trunk-group-tests-l2leaf1a
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   pod_name: TRUNK_GROUP_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -73,6 +73,7 @@ ethernet_interfaces:
 hostname: trunk-group-tests-l2leaf1b
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   pod_name: TRUNK_GROUP_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
@@ -42,6 +42,7 @@ ethernet_interfaces:
 hostname: trunk-group-tests-l2leaf3
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   pod_name: TRUNK_GROUP_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
@@ -42,6 +42,7 @@ ethernet_interfaces:
 hostname: trunk-group-tests-l2leaf4
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   pod_name: TRUNK_GROUP_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-child.yml
@@ -17,6 +17,7 @@ ethernet_interfaces:
 hostname: uplink-native-vlan-child
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-grandparent.yml
@@ -17,6 +17,7 @@ ethernet_interfaces:
 hostname: uplink-native-vlan-grandparent
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink-native-vlan-parent.yml
@@ -27,6 +27,7 @@ ethernet_interfaces:
 hostname: uplink-native-vlan-parent
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_l2leaf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_l2leaf.yml
@@ -53,6 +53,7 @@ flow_tracking:
 hostname: uplink_lan_l2leaf
 ip_igmp_snooping:
   globally_enabled: true
+ip_routing: false
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -147,6 +147,7 @@ class AvdStructuredConfigBaseProtocol(
     def ip_routing(self) -> None:
         """Set ip_routing, ip_routing_ipv6_interfaces and ipv6_unicast_routing based on underlay_rfc5549 variable."""
         if not self.shared_utils.underlay_router and not self.shared_utils.node_config.always_configure_ip_routing:
+            self.structured_config.ip_routing = False
             return
 
         if self.inputs.underlay_rfc5549 or self.shared_utils.underlay_ipv6:


### PR DESCRIPTION
## Change Summary

set ip_routing=false for node type that are not underlay_routers

This probably will have to wait till 7.x release since it explicitly renders `no ip routing`

## Related Issue(s)

Fixes #6601 

## Component(s) name

`arista.avd.eos_desings`

## Proposed changes
update __init__.py script that renders the structured config to set `ip_routing = False` if underlay router and `always_configure_ip_routing` are not set

No data-model changes

## How to test
Set a device node type as l2leaf or l2spine and validate the missing ! is now rendered before the ip routing portion of the configuration and `ip_routing: False` is set in the structured_config

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
