### PR TITLE
Fix(eos_designs): Fix missing source interface for sflow_settings.export_to_cloudvision

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-settings.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-settings.cfg
@@ -18,6 +18,7 @@ ip name-server vrf INBAND_MGMT_VRF 10.10.10.1 priority 1
 dns domain testfabric.local
 !
 sflow vrf INBAND_MGMT_VRF destination 127.0.0.1 6343
+sflow vrf INBAND_MGMT_VRF source-interface Vlan4092
 sflow run
 !
 vlan 4092

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
@@ -135,6 +135,7 @@ sflow:
     destinations:
     - destination: 127.0.0.1
       port: 6343
+    source_interface: Vlan4092
   run: true
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:

--- a/python-avd/pyavd/_eos_designs/structured_config/flows/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/flows/__init__.py
@@ -38,8 +38,11 @@ class AvdStructuredConfigFlows(StructuredConfigGenerator):
             return
 
         sflow_settings = self.inputs.sflow_settings
-        destinations = sflow_settings.destinations
-        if not destinations and not sflow_settings.export_to_cloudvision.enabled:
+        destinations = sflow_settings.destinations._natural_sorted(sort_key="destination")
+        if sflow_settings.export_to_cloudvision.enabled:
+            destinations.append(EosDesigns.SflowSettings.DestinationsItem(destination="127.0.0.1", port=6343, vrf=sflow_settings.export_to_cloudvision.vrf))
+
+        if not destinations:
             msg = "Either `sflow_settings.destinations` or `sflow_settings.export_to_cloudvision.enabled: true` is required to configure `sflow`."
             raise AristaAvdInvalidInputsError(msg)
 
@@ -47,7 +50,7 @@ class AvdStructuredConfigFlows(StructuredConfigGenerator):
         # and at least one destination.
         self.structured_config.sflow._update(run=True, polling_interval=sflow_settings.polling_interval, sample=sflow_settings.sample.rate)
 
-        for destination in natural_sort(destinations, "destination"):
+        for destination in destinations:
             destination: EosDesigns.SflowSettings.DestinationsItem
             sflow_vrf, source_interface = self.shared_utils.get_vrf_and_source_interface(
                 vrf_input=destination.vrf,
@@ -65,11 +68,6 @@ class AvdStructuredConfigFlows(StructuredConfigGenerator):
                 vrf_item.destinations.append_new(destination=destination.destination, port=destination.port)
                 vrf_item.source_interface = source_interface
                 self.structured_config.sflow.vrfs.append(vrf_item)
-
-        if sflow_settings.export_to_cloudvision.enabled:
-            sflow_vrf = self.shared_utils.get_vrf(sflow_settings.export_to_cloudvision.vrf, context="sflow_settings.export_to_cloudvision.vrf")
-            vrf_item = self.structured_config.sflow.vrfs.obtain(sflow_vrf)
-            vrf_item.destinations.append_new(destination="127.0.0.1", port=6343)
 
     @cached_property
     def _enable_sflow(self) -> bool:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix missing source interface for sflow_settings.export_to_cloudvision

## Related Issue(s)

The recently introduced `sflow_settings.export_to_cloudvision` only configured the destination of 127.0.0.1, but did nto configure the source interface, which is required for the sflow daemon to start.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Updated logic to insert terminattr in the list of destinations and use the same logic for all destinations.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Existing molecule shows the change.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
