### PR TITLE
Feat(eos_cli_config_gen): Set management api http session timeout

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1070,9 +1070,10 @@ management console
 
 #### Management API HTTP Summary
 
-| HTTP | HTTPS | UNIX-Socket | Default Services |
-| ---- | ----- | ----------- | ---------------- |
-| False | True | True | True |
+| HTTP | HTTPS | UNIX-Socket | Default Services | Session Timeout |
+| ---- | ----- | ----------- | ---------------- | --------------- |
+| False | True | True | True | 60 |
+ |
 
 Management HTTPS is using the SSL profile SSL_PROFILE
 
@@ -1181,6 +1182,7 @@ lRIvIpbuqzZ1QzAdWwCX/5mgBk/xoI88N3EcxvgEJJhiXihYwW/630KkKETqnu64
 -----END PRIVATE KEY-----
    EOF
    no shutdown
+   session timeout 60
    !
    vrf MGMT
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1182,7 +1182,7 @@ lRIvIpbuqzZ1QzAdWwCX/5mgBk/xoI88N3EcxvgEJJhiXihYwW/630KkKETqnu64
 -----END PRIVATE KEY-----
    EOF
    no shutdown
-   session timeout 60
+   session timeout 60 minutes
    !
    vrf MGMT
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -297,9 +297,9 @@ management cvx
 
 #### Management API HTTP Summary
 
-| HTTP | HTTPS | UNIX-Socket | Default Services |
-| ---- | ----- | ----------- | ---------------- |
-| True | False | - | False |
+| HTTP | HTTPS | UNIX-Socket | Default Services | Session Timeout |
+| ---- | ----- | ----------- | ---------------- | --------------- |
+| True | False | - | False | 1440 |
 
 #### Management API HTTP Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1706,7 +1706,7 @@ lRIvIpbuqzZ1QzAdWwCX/5mgBk/xoI88N3EcxvgEJJhiXihYwW/630KkKETqnu64
 -----END PRIVATE KEY-----
    EOF
    no shutdown
-   session timeout 60
+   session timeout 60 minutes
    !
    vrf MGMT
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1706,6 +1706,7 @@ lRIvIpbuqzZ1QzAdWwCX/5mgBk/xoI88N3EcxvgEJJhiXihYwW/630KkKETqnu64
 -----END PRIVATE KEY-----
    EOF
    no shutdown
+   session timeout 60
    !
    vrf MGMT
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-api-http.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-api-http.yml
@@ -5,6 +5,7 @@ management_api_http:
   enable_unix: true
   https_ssl_profile: SSL_PROFILE
   default_services: true
+  session_timeout: 60 # GH Issue 6502
   enable_vrfs:
     - name: default
       access_group: ACL-API

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-api-http.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-api-http.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;enable_unix</samp>](## "management_api_http.enable_unix") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;https_ssl_profile</samp>](## "management_api_http.https_ssl_profile") | String |  |  |  | SSL Profile Name. |
     | [<samp>&nbsp;&nbsp;default_services</samp>](## "management_api_http.default_services") | Boolean |  |  |  | Enable default services: capi-doc and tapagg. |
-    | [<samp>&nbsp;&nbsp;session_timeout</samp>](## "management_api_http.session_timeout") | Integer |  |  | Min: 0<br>Max: 1440 | User session timeout value in minutes <1-1440> |
+    | [<samp>&nbsp;&nbsp;session_timeout</samp>](## "management_api_http.session_timeout") | Integer |  |  | Min: 1<br>Max: 1440 | User session timeout value in minutes <1-1440> |
     | [<samp>&nbsp;&nbsp;enable_vrfs</samp>](## "management_api_http.enable_vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "management_api_http.enable_vrfs.[].name") | String | Required, Unique |  |  | VRF Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "management_api_http.enable_vrfs.[].access_group") | String |  |  |  | Standard IPv4 ACL name. |
@@ -37,7 +37,7 @@
       default_services: <bool>
 
       # User session timeout value in minutes <1-1440>
-      session_timeout: <int; 0-1440>
+      session_timeout: <int; 1-1440>
       enable_vrfs:
 
           # VRF Name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-api-http.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-api-http.md
@@ -13,6 +13,7 @@
     | [<samp>&nbsp;&nbsp;enable_unix</samp>](## "management_api_http.enable_unix") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;https_ssl_profile</samp>](## "management_api_http.https_ssl_profile") | String |  |  |  | SSL Profile Name. |
     | [<samp>&nbsp;&nbsp;default_services</samp>](## "management_api_http.default_services") | Boolean |  |  |  | Enable default services: capi-doc and tapagg. |
+    | [<samp>&nbsp;&nbsp;session_timeout</samp>](## "management_api_http.session_timeout") | Integer |  |  | Min: 0<br>Max: 1440 | User session timeout value in minutes <1-1440> |
     | [<samp>&nbsp;&nbsp;enable_vrfs</samp>](## "management_api_http.enable_vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "management_api_http.enable_vrfs.[].name") | String | Required, Unique |  |  | VRF Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group</samp>](## "management_api_http.enable_vrfs.[].access_group") | String |  |  |  | Standard IPv4 ACL name. |
@@ -34,6 +35,9 @@
 
       # Enable default services: capi-doc and tapagg.
       default_services: <bool>
+
+      # User session timeout value in minutes <1-1440>
+      session_timeout: <int; 0-1440>
       enable_vrfs:
 
           # VRF Name.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-api-http.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-api-http.j2
@@ -12,8 +12,8 @@
 
 | HTTP | HTTPS | UNIX-Socket | Default Services | Session Timeout |
 | ---- | ----- | ----------- | ---------------- | --------------- |
-| {{ management_api_http.enable_http | arista.avd.default(false) }} | {{ management_api_http.enable_https | arista.avd.default(true) }} | {{ management_api_http.enable_unix | arista.avd.default('-') }} | {{ management_api_http.default_services | arista.avd.default('-') }} |
-{%     if management_api_http.enable_https is arista.avd.defined(true) and management_api_http.https_ssl_profile is arista.avd.defined %} | {{ management_api_http.enable_unix | arista.avd.default('1440') }}
+| {{ management_api_http.enable_http | arista.avd.default(false) }} | {{ management_api_http.enable_https | arista.avd.default(true) }} | {{ management_api_http.enable_unix | arista.avd.default('-') }} | {{ management_api_http.default_services | arista.avd.default('-') }} | {{ management_api_http.session_timeout | arista.avd.default(1440) }} |
+{%     if management_api_http.enable_https is arista.avd.defined(true) and management_api_http.https_ssl_profile is arista.avd.defined %} |
 
 Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profile }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-api-http.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-api-http.j2
@@ -10,10 +10,10 @@
 
 #### Management API HTTP Summary
 
-| HTTP | HTTPS | UNIX-Socket | Default Services |
-| ---- | ----- | ----------- | ---------------- |
+| HTTP | HTTPS | UNIX-Socket | Default Services | Session Timeout |
+| ---- | ----- | ----------- | ---------------- | --------------- |
 | {{ management_api_http.enable_http | arista.avd.default(false) }} | {{ management_api_http.enable_https | arista.avd.default(true) }} | {{ management_api_http.enable_unix | arista.avd.default('-') }} | {{ management_api_http.default_services | arista.avd.default('-') }} |
-{%     if management_api_http.enable_https is arista.avd.defined(true) and management_api_http.https_ssl_profile is arista.avd.defined %}
+{%     if management_api_http.enable_https is arista.avd.defined(true) and management_api_http.https_ssl_profile is arista.avd.defined %} | {{ management_api_http.enable_unix | arista.avd.default('1440') }}
 
 Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profile }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
@@ -38,7 +38,7 @@ management api http-commands
    EOF
 {%     endif %}
    no shutdown
-{%     if management_api_http.session_timeout is arista.avd.defined(true) %}
+{%     if management_api_http.session_timeout is arista.avd.defined %}
    session timeout {{ management_api_http.session_timeout }}
 {%     endif %}
 {%     for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort(sort_key='name', ignore_case=false) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
@@ -38,6 +38,9 @@ management api http-commands
    EOF
 {%     endif %}
    no shutdown
+{%     if management_api_http.session_timeout is arista.avd.defined(true) %}
+   session timeout {{ management_api_http.session_timeout }}
+{%     endif %}
 {%     for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort(sort_key='name', ignore_case=false) %}
    !
    vrf {{ vrf.name }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-api-http.j2
@@ -39,7 +39,7 @@ management api http-commands
 {%     endif %}
    no shutdown
 {%     if management_api_http.session_timeout is arista.avd.defined %}
-   session timeout {{ management_api_http.session_timeout }}
+   session timeout {{ management_api_http.session_timeout }} minutes
 {%     endif %}
 {%     for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort(sort_key='name', ignore_case=false) %}
    !

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -21855,6 +21855,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "enable_unix": {"type": bool},
             "https_ssl_profile": {"type": str},
             "default_services": {"type": bool},
+            "session_timeout": {"type": int},
             "enable_vrfs": {"type": EnableVrfs},
             "protocol_https_certificate": {"type": ProtocolHttpsCertificate},
         }
@@ -21865,6 +21866,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """SSL Profile Name."""
         default_services: bool | None
         """Enable default services: capi-doc and tapagg."""
+        session_timeout: int | None
+        """User session timeout value in minutes <1-1440>"""
         enable_vrfs: EnableVrfs
         """Subclass of AvdIndexedList with `EnableVrfsItem` items. Primary key is `name` (`str`)."""
         protocol_https_certificate: ProtocolHttpsCertificate
@@ -21880,6 +21883,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 enable_unix: bool | None | UndefinedType = Undefined,
                 https_ssl_profile: str | None | UndefinedType = Undefined,
                 default_services: bool | None | UndefinedType = Undefined,
+                session_timeout: int | None | UndefinedType = Undefined,
                 enable_vrfs: EnableVrfs | UndefinedType = Undefined,
                 protocol_https_certificate: ProtocolHttpsCertificate | UndefinedType = Undefined,
             ) -> None:
@@ -21895,6 +21899,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     enable_unix: enable_unix
                     https_ssl_profile: SSL Profile Name.
                     default_services: Enable default services: capi-doc and tapagg.
+                    session_timeout: User session timeout value in minutes <1-1440>
                     enable_vrfs: Subclass of AvdIndexedList with `EnableVrfsItem` items. Primary key is `name` (`str`).
                     protocol_https_certificate: Subclass of AvdModel.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -8656,7 +8656,7 @@ keys:
         description: 'Enable default services: capi-doc and tapagg.'
       session_timeout:
         type: int
-        min: 0
+        min: 1
         max: 1440
         description: User session timeout value in minutes <1-1440>
         convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -8654,6 +8654,13 @@ keys:
       default_services:
         type: bool
         description: 'Enable default services: capi-doc and tapagg.'
+      session_timeout:
+        type: int
+        min: 0
+        max: 1440
+        description: User session timeout value in minutes <1-1440>
+        convert_types:
+        - str
       enable_vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
@@ -23,7 +23,7 @@ keys:
         description: "Enable default services: capi-doc and tapagg."
       session_timeout:
         type: int
-        min: 0
+        min: 1
         max: 1440
         description: "User session timeout value in minutes <1-1440>"
         convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
@@ -21,6 +21,13 @@ keys:
       default_services:
         type: bool
         description: "Enable default services: capi-doc and tapagg."
+      session_timeout:
+        type: int
+        min: 0
+        max: 1440
+        description: "User session timeout value in minutes <1-1440>"
+        convert_types:
+          - str
       enable_vrfs:
         type: list
         primary_key: name


### PR DESCRIPTION
## Change Summary

Add key for management api http-commands control plane session timeout.

## Related Issue(s)

Fixes #6502 
## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add new kvp.

```yaml
session_timeout:
        type: int
        min: 0
        max: 1440
        description: "User session timeout value in minutes <1-1440>"
        convert_types:
          - str
```

Data model example

```yaml
session_timeout: 60
```

Also added column to documentation.

## How to test
Verified with molecule.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code has been rebased from devel before I start
- [ x ] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ x ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
