### PR TITLE
Feat(cv_deploy): Protect CVDeploy attributes from invalid values

### DIFF
--- a/python-avd/pyavd/_cv/workflows/models.py
+++ b/python-avd/pyavd/_cv/workflows/models.py
@@ -12,6 +12,7 @@ from uuid import NAMESPACE_DNS, uuid4, uuid5
 from pyavd._cv.client.configlet import ASSIGNMENT_MATCH_POLICY_MAP
 from pyavd._cv.client.exceptions import CVManifestError
 from pyavd._cv.client.models import CVTag, CVTagAssignment
+from pyavd._errors import AristaAvdInvalidInputsError
 
 AVD_NAMESPACE = uuid5(NAMESPACE_DNS, "avd.arista.com")
 AVD_ENTITY_PREFIX = "avd_"
@@ -200,9 +201,12 @@ class CVDevice:
     Device hostname or intended hostname.
     `serial_number` or `system_mac_address` must be set if the hostname is not already configured on the device or
     if the hostname is not unique.
+    An attempt to assign an empty string will result in raising AristaAvdInvalidInputsError.
     """
     serial_number: str | None = None
+    """ An attempt to assign an empty string will result in raising AristaAvdInvalidInputsError. """
     system_mac_address: str | None = None
+    """ An attempt to assign an empty string will result in raising AristaAvdInvalidInputsError. """
     _exists_on_cv: bool | None = None
     """ Do not set this manually. """
     _streaming: bool | None = None
@@ -210,6 +214,26 @@ class CVDevice:
     Device's streaming status.
     Do not set this manually.
     """
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Validate value before setting an attribute."""
+        if name == "hostname" or (name in ("serial_number", "system_mac_address") and value is not None):
+            self._validate_non_empty_str(name, value)
+        # Use object.__setattr__ to avoid recursive calling of __setattr__.
+        object.__setattr__(self, name, value)
+
+    def _validate_non_empty_str(self, name: str, value: str) -> None:
+        """Validate that a string field is not empty."""
+        # Fetch original hostname in case this is a post-initialization update of a hostname field
+        original_hostname = getattr(self, "hostname", None)
+        hostname_context = f" of the device '{original_hostname}'" if original_hostname is not None else " of the CVDevice"
+
+        if not isinstance(value, str):
+            msg = f"Field '{name}'{hostname_context} cannot be set to a value '{value}' of type '{type(value)}'. Please verify your inputs."
+            raise AristaAvdInvalidInputsError(message=msg)
+        if not value.strip():
+            msg = f"Field '{name}'{hostname_context} cannot be an empty string. Please verify your inputs."
+            raise AristaAvdInvalidInputsError(message=msg)
 
 
 @dataclass

--- a/python-avd/tests/pyavd/cv/workflows/test_models.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_models.py
@@ -10,7 +10,8 @@ import pytest
 from pyavd._cv.api.arista.configlet.v1 import ConfigletAssignment, ConfigletAssignmentKey, MatchPolicy
 from pyavd._cv.api.fmp import RepeatedString
 from pyavd._cv.client.exceptions import CVManifestError
-from pyavd._cv.workflows.models import AVD_ENTITY_PREFIX, AvdConfiglet, AvdContainer, AvdManifest, CVContainer, CVManifest
+from pyavd._cv.workflows.models import AVD_ENTITY_PREFIX, AvdConfiglet, AvdContainer, AvdManifest, CVContainer, CVDevice, CVManifest
+from pyavd._errors import AristaAvdInvalidInputsError
 
 from .helpers import generate_id
 
@@ -448,3 +449,157 @@ class TestAvdManifestFromDict:
         """Tests that ValueError is raised for invalid AvdManifest data."""
         with pytest.raises(ValueError, match=match_str):
             AvdManifest.from_dict(invalid_data)
+
+
+class TestCVDevice:
+    @pytest.mark.parametrize(
+        ("optional_arguments"),
+        [
+            pytest.param({}, id="hostname_only"),
+            pytest.param({"serial_number": None}, id="hostname_and_serial_number_none"),
+            pytest.param({"system_mac_address": None}, id="hostname_and_system_mac_address_none"),
+            pytest.param({"serial_number": None, "system_mac_address": None}, id="hostname_and_serial_number_none_and_system_mac_address_none"),
+            pytest.param({"serial_number": "serial_1"}, id="hostname_and_serial_number"),
+            pytest.param({"serial_number": "serial_1", "system_mac_address": None}, id="hostname_and_serial_number_and_system_mac_address_none"),
+            pytest.param({"serial_number": "serial_1", "system_mac_address": "mac_1"}, id="hostname_and_serial_number_and_system_mac_address"),
+            pytest.param({"system_mac_address": "mac_1"}, id="hostname_and_system_mac_address"),
+            pytest.param({"serial_number": None, "system_mac_address": "mac_1"}, id="hostname_and_serial_number_none_and_system_mac_address"),
+        ],
+    )
+    def test_success(self, optional_arguments: dict[str, Any]) -> None:
+        """Tests creation of CVDevice and ability to successfully override parameters later."""
+        # Test initialization
+        hostname = "device_1"
+        device = CVDevice(hostname=hostname, **optional_arguments)
+        assert device.hostname == hostname
+        assert device.serial_number == optional_arguments.get("serial_number")
+        assert device.system_mac_address == optional_arguments.get("system_mac_address")
+
+        # Test overriding
+        device = CVDevice(hostname="device_2")
+        for key, value in optional_arguments.items():
+            setattr(device, key, value)
+            assert getattr(device, key) == value
+
+    @pytest.mark.parametrize(
+        ("arguments", "expected_exception"),
+        [
+            pytest.param({}, TypeError("missing 1 required positional argument: 'hostname'"), id="no_hostname_1"),
+            pytest.param({"serial_number": None}, TypeError("missing 1 required positional argument: 'hostname'"), id="no_hostname_2"),
+            pytest.param({"serial_number": "serial_1"}, TypeError("missing 1 required positional argument: 'hostname'"), id="no_hostname_3"),
+            pytest.param({"system_mac_address": None}, TypeError("missing 1 required positional argument: 'hostname'"), id="no_hostname_4"),
+            pytest.param({"system_mac_address": "mac_1"}, TypeError("missing 1 required positional argument: 'hostname'"), id="no_hostname_5"),
+            pytest.param(
+                {"hostname": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'hostname' of the CVDevice cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="hostname_int",
+            ),
+            pytest.param(
+                {"hostname": None},
+                AristaAvdInvalidInputsError(
+                    "Field 'hostname' of the CVDevice cannot be set to a value 'None' of type '<class 'NoneType'>'. Please verify your inputs."
+                ),
+                id="hostname_none",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "serial_number": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'serial_number' of the device 'device_1' cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="serial_number_int",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "serial_number": ""},
+                AristaAvdInvalidInputsError("Field 'serial_number' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="serial_number_empty_str_1",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "serial_number": " "},
+                AristaAvdInvalidInputsError("Field 'serial_number' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="serial_number_empty_str_2",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "system_mac_address": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'system_mac_address' of the device 'device_1' cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="system_mac_address_int",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "system_mac_address": ""},
+                AristaAvdInvalidInputsError("Field 'system_mac_address' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="system_mac_address_empty_str_1",
+            ),
+            pytest.param(
+                {"hostname": "device_1", "system_mac_address": " "},
+                AristaAvdInvalidInputsError("Field 'system_mac_address' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="system_mac_address_empty_str_2",
+            ),
+        ],
+    )
+    def test_initialization_failure(self, arguments: dict[str, Any], expected_exception: Exception) -> None:
+        """Tests inability to create CVDevice with incorrect argument values."""
+        with pytest.raises(type(expected_exception), match=expected_exception.args[0]):
+            _ = CVDevice(**arguments)
+
+    @pytest.mark.parametrize(
+        ("arguments", "expected_exception"),
+        [
+            pytest.param(
+                {"hostname": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'hostname' of the device 'device_1' cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="hostname_int",
+            ),
+            pytest.param(
+                {"hostname": None},
+                AristaAvdInvalidInputsError(
+                    "Field 'hostname' of the device 'device_1' cannot be set to a value 'None' of type '<class 'NoneType'>'. Please verify your inputs."
+                ),
+                id="hostname_none",
+            ),
+            pytest.param(
+                {"serial_number": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'serial_number' of the device 'device_1' cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="serial_number_int",
+            ),
+            pytest.param(
+                {"serial_number": ""},
+                AristaAvdInvalidInputsError("Field 'serial_number' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="serial_number_empty_str_1",
+            ),
+            pytest.param(
+                {"serial_number": " "},
+                AristaAvdInvalidInputsError("Field 'serial_number' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="serial_number_empty_str_2",
+            ),
+            pytest.param(
+                {"system_mac_address": 123},
+                AristaAvdInvalidInputsError(
+                    "Field 'system_mac_address' of the device 'device_1' cannot be set to a value '123' of type '<class 'int'>'. Please verify your inputs."
+                ),
+                id="system_mac_address_int",
+            ),
+            pytest.param(
+                {"system_mac_address": ""},
+                AristaAvdInvalidInputsError("Field 'system_mac_address' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="system_mac_address_empty_str_1",
+            ),
+            pytest.param(
+                {"system_mac_address": " "},
+                AristaAvdInvalidInputsError("Field 'system_mac_address' of the device 'device_1' cannot be an empty string. Please verify your inputs."),
+                id="system_mac_address_empty_str_2",
+            ),
+        ],
+    )
+    def test_overriding_failure(self, arguments: dict[str, Any], expected_exception: Exception) -> None:
+        """Test inability to override CVDevice string attributes with incorrect values."""
+        device = CVDevice(hostname="device_1")
+        for key, value in arguments.items():
+            with pytest.raises(type(expected_exception), match=expected_exception.args[0]):
+                setattr(device, key, value)


### PR DESCRIPTION
## Change Summary

Enforce validation of the values set for `hostname`, `serial_number` and `system_mac_address` to make sure we can not update TOPOLOGY inputs with incorrect values.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
Use explisit __setattr__ method with validation layer for `hostname`, `serial_number` and `system_mac_address` attributes to:
1. Protect from initial incorrect inputs (like `serial_number` set in group/host vars to an empty string or smth.)
2. Protect from propagating incorrect input value into the TOPOLOGY studio intups

## How to test
Pytest `python-avd/tests/pyavd/cv/workflows/test_models.py::TestCVDevice`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
