### PR TITLE
Fix(eos_cli_config_gen): Fix typo in router multicast template

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host5.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host5.md
@@ -6,6 +6,8 @@
   - [Management Interfaces](#management-interfaces)
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
+- [Multicast](#multicast)
+  - [Router Multicast](#router-multicast)
 
 ## Management
 
@@ -52,4 +54,22 @@ interface Management1
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.0.2.1:9910,192.0.2.2:9910,192.0.2.3:9910 -cvauth=token,/tmp/token -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
+```
+
+## Multicast
+
+### Router Multicast
+
+#### IP Router Multicast Summary
+
+- IPv6 software forwarding is handled by the Linux kernel.
+
+#### Router Multicast Device Configuration
+
+```eos
+!
+router multicast
+   !
+   ipv6
+      software-forwarding kernel
 ```

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host5.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host5.cfg
@@ -7,3 +7,8 @@ interface Management1
    description OOB_MANAGEMENT
    vrf MGMT
    ip address 10.73.255.122/24
+!
+router multicast
+   !
+   ipv6
+      software-forwarding kernel

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host5/router-multicast.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host5/router-multicast.yml
@@ -1,0 +1,4 @@
+---
+router_multicast:
+  ipv6:
+    software_forwarding: kernel

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-multicast.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-multicast.j2
@@ -45,7 +45,7 @@ router multicast
       routing
 {%         endif %}
 {%         if router_multicast.ipv6.software_forwarding is arista.avd.defined %}
-      software-forwarding {{ router_multicast.ipv4.software_forwarding }}
+      software-forwarding {{ router_multicast.ipv6.software_forwarding }}
 {%         endif %}
 {%     endif %}
 {%     for vrf in router_multicast.vrfs | arista.avd.natural_sort('name', ignore_case=false) %}


### PR DESCRIPTION
## Change Summary

Fix typo in router multicast template

## Related Issue(s)

Fixes #6630 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix typo for `router_multicast.ipv6.software_forwarding` in router multicast template

## How to test
Molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
