### PR TITLE
Test(eos_designs): Update the eos_designs_unit_tests molecule scenario to fix deprecation warnings

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -59,9 +59,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
 !
-ip radius source-interface Vlan123
-ip radius vrf MGMT source-interface Vlan125
+ip radius vrf default source-interface Vlan123
 ip radius vrf MGMT1 source-interface Vlan125
+ip radius vrf MGMT source-interface Vlan125
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -39,13 +39,13 @@ ethernet_interfaces:
 hostname: host1
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius:
-  source_interface: Vlan123
-  vrfs:
-  - name: MGMT1
-    source_interface: Vlan125
-  - name: MGMT
-    source_interface: Vlan125
+ip_radius_source_interfaces:
+- name: Vlan123
+  vrf: default
+- name: Vlan125
+  vrf: MGMT1
+- name: Vlan125
+  vrf: MGMT
 ip_routing: true
 loopback_interfaces:
 - name: Loopback0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
@@ -32,9 +32,6 @@ l3leaf:
 # Used by source-interfaces test: Testing that the generated source interfaces do not contain the VRF if VRF "default"
 mgmt_interface_vrf: default
 
-avd_7_behaviors:
-  # Test for new behaviour of IP RADIUS server commands
-  ip_radius_source_interface_setting: true
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-1.cfg
@@ -90,7 +90,7 @@ interface Management1
    ip address 192.168.0.2/24
 no ip routing vrf MGMT
 !
-ip radius vrf default source-interface Vlan123
+ip radius source-interface Vlan123
 ip radius vrf MGMT source-interface Vlan125
 !
 ip tacacs vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/aaa-settings-3.cfg
@@ -67,8 +67,8 @@ interface Vlan4092
    ip address 192.168.1.2/24
 no ip routing vrf MGMT
 !
-ip radius vrf MGMT source-interface Ma1/1
 ip radius vrf INBAND_MGMT source-interface Vlan123
+ip radius vrf MGMT source-interface Ma1/1
 !
 ip tacacs vrf MGMT source-interface Management1
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -435,9 +435,10 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
-ip_radius_source_interfaces:
-- name: Management99
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management99
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 ipv6_static_routes:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -347,9 +347,10 @@ ip_name_server:
     - ip_address: 8.8.8.8
     - ip_address: 2001:db8::1
     - ip_address: 2001:db8::2
-ip_radius_source_interfaces:
-- name: Management99
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management99
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 ipv6_static_routes:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-1.yml
@@ -174,11 +174,11 @@ enable_password:
 hostname: aaa-settings-1
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Vlan123
-  vrf: default
-- name: Vlan125
-  vrf: MGMT
+ip_radius:
+  source_interface: Vlan123
+  vrfs:
+  - name: MGMT
+    source_interface: Vlan125
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
@@ -43,9 +43,10 @@ enable_password:
 hostname: aaa-settings-2
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Vlan4092
-  vrf: INBAND_MGMT
+ip_radius:
+  vrfs:
+  - name: INBAND_MGMT
+    source_interface: Vlan4092
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
@@ -47,11 +47,12 @@ enable_password:
 hostname: aaa-settings-3
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Vlan123
-  vrf: INBAND_MGMT
-- name: Ma1/1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: INBAND_MGMT
+    source_interface: Vlan123
+  - name: MGMT
+    source_interface: Ma1/1
 ip_tacacs_source_interfaces:
 - name: Vlan123
   vrf: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -524,9 +524,10 @@ ethernet_interfaces:
 hostname: connected_endpoints
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 link_tracking_groups:
 - name: LT_GROUP1
   recovery_delay: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-1.yml
@@ -22,9 +22,10 @@ enable_password:
 hostname: dot1x-settings-1
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
@@ -51,9 +51,10 @@ enable_password:
 hostname: dot1x-settings-2
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-3.yml
@@ -14,9 +14,10 @@ enable_password:
 hostname: dot1x-settings-3
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-4.yml
@@ -31,9 +31,10 @@ enable_password:
 hostname: dot1x-settings-4
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 management_interfaces:
 - name: Management1
   description: OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf1-dot1x-evpn-redistribution-enabled-vlan-aware-bundles.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf1-dot1x-evpn-redistribution-enabled-vlan-aware-bundles.yml
@@ -14,9 +14,10 @@ enable_password:
 hostname: leaf1-dot1x-evpn-redistribution-enabled-vlan-aware-bundles
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 ip_routing: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99
 loopback_interfaces:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf1-dot1x-evpn-redistribution-enabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf1-dot1x-evpn-redistribution-enabled.yml
@@ -14,9 +14,10 @@ enable_password:
 hostname: leaf1-dot1x-evpn-redistribution-enabled
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 ip_routing: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99
 loopback_interfaces:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf2-dot1x-evpn-redistribution-disabled-vlan-aware-bundles.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf2-dot1x-evpn-redistribution-disabled-vlan-aware-bundles.yml
@@ -14,9 +14,10 @@ enable_password:
 hostname: leaf2-dot1x-evpn-redistribution-disabled-vlan-aware-bundles
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 ip_routing: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99
 loopback_interfaces:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf2-dot1x-evpn-redistribution-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/leaf2-dot1x-evpn-redistribution-disabled.yml
@@ -14,9 +14,10 @@ enable_password:
 hostname: leaf2-dot1x-evpn-redistribution-disabled
 ip_igmp_snooping:
   globally_enabled: true
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 ip_routing: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99
 loopback_interfaces:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/only-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/only-connected-endpoints.yml
@@ -238,9 +238,10 @@ ethernet_interfaces:
       allowed_vlan: 1-100
       native_vlan: 1000
 hostname: only-connected-endpoints
-ip_radius_source_interfaces:
-- name: Management1
-  vrf: MGMT
+ip_radius:
+  vrfs:
+  - name: MGMT
+    source_interface: Management1
 management_api_http: null
 management_interfaces:
 - name: Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
@@ -15,6 +15,10 @@ overlay_rt_type:
 dot1x_settings:
   enabled: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   local_users:
     - name: admin

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-1.yml
@@ -7,6 +7,10 @@ l2leaf:
     - name: aaa-settings-1
       mgmt_ip: 192.168.0.2/24
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   # adding test for enable_password.password
   enable_password:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-2.yml
@@ -10,6 +10,10 @@ l2leaf:
 
 default_mgmt_method: inband
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   tacacs:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/aaa-settings-3.yml
@@ -11,6 +11,10 @@ l2leaf:
 
 default_mgmt_method: oob
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   tacacs:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -249,6 +249,10 @@ monitor:
 dot1x_settings:
   enabled: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-1.yml
@@ -10,6 +10,10 @@ l2leaf:
 dot1x_settings:
   enabled: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-2.yml
@@ -7,6 +7,10 @@ l2leaf:
     - name: dot1x-settings-2
       mgmt_ip: 192.168.0.2/24
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 dot1x_settings:
   enabled: true
   authentication:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-3.yml
@@ -16,6 +16,10 @@ dot1x_settings:
   dynamic_authorization:
     enabled: false
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-4.yml
@@ -14,6 +14,10 @@ dot1x_settings:
   accounting:
     radius_groups: [agni-server-group, radius]
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf1-dot1x-evpn-redistribution-enabled-vlan-aware-bundles.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf1-dot1x-evpn-redistribution-enabled-vlan-aware-bundles.yml
@@ -5,6 +5,10 @@ dot1x_settings:
     enabled: false
   redistribute_in_evpn: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf1-dot1x-evpn-redistribution-enabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf1-dot1x-evpn-redistribution-enabled.yml
@@ -5,6 +5,10 @@ dot1x_settings:
     enabled: false
   redistribute_in_evpn: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf2-dot1x-evpn-redistribution-disabled-vlan-aware-bundles.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf2-dot1x-evpn-redistribution-disabled-vlan-aware-bundles.yml
@@ -5,6 +5,10 @@ dot1x_settings:
     enabled: false
   redistribute_in_evpn: false
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf2-dot1x-evpn-redistribution-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/leaf2-dot1x-evpn-redistribution-disabled.yml
@@ -5,6 +5,10 @@ dot1x_settings:
     enabled: false
   redistribute_in_evpn: false
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/only-connected-endpoints.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/only-connected-endpoints.yml
@@ -61,6 +61,10 @@ network_ports:
 dot1x_settings:
   enabled: true
 
+avd_7_behaviors:
+  # Test for new behaviour of IP RADIUS server commands
+  ip_radius_source_interface_setting: true
+
 aaa_settings:
   radius:
     servers:


### PR DESCRIPTION
## Change Summary

Update the `eos_designs_unit_tests` molecule scenario to fix deprecation warnings for `ip_radius_source_interfaces`

## Related Issue(s)

Fixes #https://github.com/aristanetworks/avd/issues/6634

## Component(s) name

`arista.avd.eos_designs`

## How to test
Run `eos_designs_unit_tests` molecule scenario, no deprecation warnings should be there.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
