### PR TITLE
Feat(eos_cli_config_gen): Support for cv_loss_timeout flag

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -2275,7 +2275,7 @@ kernel software forwarding ecmp
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,<removed> -cvvrf=mgt -cvsourceip=10.10.10.10 -cvgnmi -cvobscurekeyfile -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -ecodhcpaddr=127.0.0.1:67 -ipfix -ipfixaddr=10.10.10.12 -sflow -sflowaddr=10.10.10.11 -cvconfig -cvsourceintf=Vlan100
+   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,<removed> -cvvrf=mgt -cvsourceip=10.10.10.10 -cvgnmi -cvobscurekeyfile -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -ecodhcpaddr=127.0.0.1:67 -ipfix -ipfixaddr=10.10.10.12 -sflow -sflowaddr=10.10.10.11 -cvconfig -cvsourceintf=Vlan100 -cv_loss_timeout=5m
    no shutdown
 ```
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -137,7 +137,7 @@ logging event storm-control discards global
 logging event storm-control discards interval 10
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvsourceip=10.10.10.10 -cvgnmi -cvobscurekeyfile -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -ecodhcpaddr=127.0.0.1:67 -ipfix -ipfixaddr=10.10.10.12 -sflow -sflowaddr=10.10.10.11 -cvconfig -cvsourceintf=Vlan100
+   exec /usr/bin/TerminAttr -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -cvsourceip=10.10.10.10 -cvgnmi -cvobscurekeyfile -disableaaa -cvproxy=http://arista:arista@10.10.10.1:3128 -grpcaddr=mgmt/0.0.0.0:6042 -grpcreadonly -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs=/var/log/messages,/var/log/agents/ -ecodhcpaddr=127.0.0.1:67 -ipfix -ipfixaddr=10.10.10.12 -sflow -sflowaddr=10.10.10.11 -cvconfig -cvsourceintf=Vlan100 -cv_loss_timeout=5m
    no shutdown
 !
 daemon ZZZ

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/daemon-terminattr.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/daemon-terminattr.yml
@@ -25,3 +25,4 @@ daemon_terminattr:
   sflow: true
   sflowaddr: 10.10.10.11
   ipfixaddr: 10.10.10.12
+  cvlosstimeout: 5

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/daemon-terminattr.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/daemon-terminattr.yml
@@ -25,4 +25,4 @@ daemon_terminattr:
   sflow: true
   sflowaddr: 10.10.10.11
   ipfixaddr: 10.10.10.12
-  cvlosstimeout: 5
+  cv_loss_timeout: 5

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,7 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
-    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)<br> |
+    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Timeout in minutes before the device will revert to ZTP mode.<br>The recommended timeout is five minutes. |
 
 === "YAML"
 
@@ -207,6 +207,7 @@
       # Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvconfig: <bool>
 
-      # Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)
+      # Timeout in minutes before the device will revert to ZTP mode.
+      # The recommended timeout is five minutes.
       cvlosstimeout: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,7 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
-    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Timeout in minutes before the device will revert to ZTP mode.<br>The recommended timeout is five minutes. |
+    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.<br>The recommended timeout is five minutes. |
 
 === "YAML"
 
@@ -207,7 +207,7 @@
       # Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvconfig: <bool>
 
-      # Timeout in minutes before the device will revert to ZTP mode.
+      # Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.
       # The recommended timeout is five minutes.
       cvlosstimeout: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,7 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
-    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.<br>The recommended timeout is five minutes. |
+    | [<samp>&nbsp;&nbsp;cv_loss_timeout</samp>](## "daemon_terminattr.cv_loss_timeout") | Integer |  |  |  | Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.<br>The recommended timeout is five minutes. |
 
 === "YAML"
 
@@ -209,5 +209,5 @@
 
       # Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.
       # The recommended timeout is five minutes.
-      cvlosstimeout: <int>
+      cv_loss_timeout: <int>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,6 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
+    | [<samp>&nbsp;&nbsp;cvlosstimeout</samp>](## "daemon_terminattr.cvlosstimeout") | Integer |  |  |  | Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)<br> |
 
 === "YAML"
 
@@ -205,4 +206,7 @@
 
       # Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvconfig: <bool>
+
+      # Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)
+      cvlosstimeout: <int>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/daemon-terminattr.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/daemon-terminattr.j2
@@ -114,6 +114,9 @@ daemon TerminAttr
 {%     if daemon_terminattr.cvsourceintf is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvsourceintf=" ~ daemon_terminattr.cvsourceintf %}
 {%     endif %}
+{%     if daemon_terminattr.cvlosstimeout is arista.avd.defined %}
+{%         set cvp_config.cli = cvp_config.cli ~ " -cv_loss_timeout=" ~ daemon_terminattr.cvlosstimeout ~ "m" %}
+{%     endif %}
    {{ cvp_config.cli }}
    no shutdown
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/daemon-terminattr.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/daemon-terminattr.j2
@@ -114,8 +114,8 @@ daemon TerminAttr
 {%     if daemon_terminattr.cvsourceintf is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvsourceintf=" ~ daemon_terminattr.cvsourceintf %}
 {%     endif %}
-{%     if daemon_terminattr.cvlosstimeout is arista.avd.defined %}
-{%         set cvp_config.cli = cvp_config.cli ~ " -cv_loss_timeout=" ~ daemon_terminattr.cvlosstimeout ~ "m" %}
+{%     if daemon_terminattr.cv_loss_timeout is arista.avd.defined %}
+{%         set cvp_config.cli = cvp_config.cli ~ " -cv_loss_timeout=" ~ daemon_terminattr.cv_loss_timeout ~ "m" %}
 {%     endif %}
    {{ cvp_config.cli }}
    no shutdown

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -3996,9 +3996,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false)."""
         cvlosstimeout: int | None
         """
-        Timeout in minutes before the device will revert to ZTP mode.
-        The recommended timeout is five
-        minutes.
+        Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to
+        CloudVision after a configuration change.
+        The recommended timeout is five minutes.
         """
 
         if TYPE_CHECKING:
@@ -4102,9 +4102,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        "127.0.0.1:6343").
                     cvconfig: Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
                     cvlosstimeout:
-                       Timeout in minutes before the device will revert to ZTP mode.
-                       The recommended timeout is five
-                       minutes.
+                       Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to
+                       CloudVision after a configuration change.
+                       The recommended timeout is five minutes.
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -3892,6 +3892,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "sflow": {"type": bool},
             "sflowaddr": {"type": str},
             "cvconfig": {"type": bool},
+            "cvlosstimeout": {"type": int},
         }
         cvaddrs: Cvaddrs
         """
@@ -3993,6 +3994,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """
         cvconfig: bool | None
         """Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false)."""
+        cvlosstimeout: int | None
+        """
+        Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended
+        interval, -cv_loss_timeout=5m.)
+        """
 
         if TYPE_CHECKING:
 
@@ -4020,6 +4026,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 sflow: bool | None | UndefinedType = Undefined,
                 sflowaddr: str | None | UndefinedType = Undefined,
                 cvconfig: bool | None | UndefinedType = Undefined,
+                cvlosstimeout: int | None | UndefinedType = Undefined,
             ) -> None:
                 """
                 DaemonTerminattr.
@@ -4093,6 +4100,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default
                        "127.0.0.1:6343").
                     cvconfig: Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
+                    cvlosstimeout:
+                       Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended
+                       interval, -cv_loss_timeout=5m.)
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -3996,8 +3996,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false)."""
         cvlosstimeout: int | None
         """
-        Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended
-        interval, -cv_loss_timeout=5m.)
+        Timeout in minutes before the device will revert to ZTP mode.
+        The recommended timeout is five
+        minutes.
         """
 
         if TYPE_CHECKING:
@@ -4101,8 +4102,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        "127.0.0.1:6343").
                     cvconfig: Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
                     cvlosstimeout:
-                       Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended
-                       interval, -cv_loss_timeout=5m.)
+                       Timeout in minutes before the device will revert to ZTP mode.
+                       The recommended timeout is five
+                       minutes.
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -3892,7 +3892,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "sflow": {"type": bool},
             "sflowaddr": {"type": str},
             "cvconfig": {"type": bool},
-            "cvlosstimeout": {"type": int},
+            "cv_loss_timeout": {"type": int},
         }
         cvaddrs: Cvaddrs
         """
@@ -3994,7 +3994,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """
         cvconfig: bool | None
         """Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false)."""
-        cvlosstimeout: int | None
+        cv_loss_timeout: int | None
         """
         Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to
         CloudVision after a configuration change.
@@ -4027,7 +4027,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 sflow: bool | None | UndefinedType = Undefined,
                 sflowaddr: str | None | UndefinedType = Undefined,
                 cvconfig: bool | None | UndefinedType = Undefined,
-                cvlosstimeout: int | None | UndefinedType = Undefined,
+                cv_loss_timeout: int | None | UndefinedType = Undefined,
             ) -> None:
                 """
                 DaemonTerminattr.
@@ -4101,7 +4101,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default
                        "127.0.0.1:6343").
                     cvconfig: Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
-                    cvlosstimeout:
+                    cv_loss_timeout:
                        Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to
                        CloudVision after a configuration change.
                        The recommended timeout is five minutes.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1673,7 +1673,7 @@ keys:
           default is false).
 
           '
-      cvlosstimeout:
+      cv_loss_timeout:
         type: int
         description: 'Timeout in minutes before the device will revert to ZTP mode
           in case of losing connectivity to CloudVision after a configuration change.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1675,7 +1675,8 @@ keys:
           '
       cvlosstimeout:
         type: int
-        description: 'Timeout in minutes before the device will revert to ZTP mode.
+        description: 'Timeout in minutes before the device will revert to ZTP mode
+          in case of losing connectivity to CloudVision after a configuration change.
 
           The recommended timeout is five minutes.'
         convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1673,6 +1673,14 @@ keys:
           default is false).
 
           '
+      cvlosstimeout:
+        type: int
+        description: 'Value in minutes before the device will revert to ZTP mode.(Five
+          minutes is the recommended interval, -cv_loss_timeout=5m.)
+
+          '
+        convert_types:
+        - str
   daemons:
     type: list
     primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1675,10 +1675,9 @@ keys:
           '
       cvlosstimeout:
         type: int
-        description: 'Value in minutes before the device will revert to ZTP mode.(Five
-          minutes is the recommended interval, -cv_loss_timeout=5m.)
+        description: 'Timeout in minutes before the device will revert to ZTP mode.
 
-          '
+          The recommended timeout is five minutes.'
         convert_types:
         - str
   daemons:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -215,7 +215,8 @@ keys:
           Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvlosstimeout:
         type: int
-        description: |
-          Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)
+        description: |-
+          Timeout in minutes before the device will revert to ZTP mode.
+          The recommended timeout is five minutes.
         convert_types:
           - str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -216,7 +216,7 @@ keys:
       cvlosstimeout:
         type: int
         description: |-
-          Timeout in minutes before the device will revert to ZTP mode.
+          Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.
           The recommended timeout is five minutes.
         convert_types:
           - str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -213,7 +213,7 @@ keys:
         type: bool
         description: |
           Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
-      cvlosstimeout:
+      cv_loss_timeout:
         type: int
         description: |-
           Timeout in minutes before the device will revert to ZTP mode in case of losing connectivity to CloudVision after a configuration change.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -213,3 +213,9 @@ keys:
         type: bool
         description: |
           Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
+      cvlosstimeout:
+        type: int
+        description: |
+          Value in minutes before the device will revert to ZTP mode.(Five minutes is the recommended interval, -cv_loss_timeout=5m.)
+        convert_types:
+          - str


### PR DESCRIPTION
## Change Summary

ZTP Fallback in Streaming Agent 

## Related Issue(s)

Fixes #6583 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add the flag directly to the Streaming Agent daemon config. The flag is -cv_loss_timeout.

## How to test
Run Molecule

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
