### PR TITLE
CI(containers): trixie to bookworm

### DIFF
--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -33,7 +33,7 @@ env:
         required: false
         type: string
         default: python
-      # From variant, e.g. "3.11-slim-trixie".
+      # From variant, e.g. "3.12-slim-bookworm".
       # This is auto-generated for python-slim based builds.
       # Only specify for special builds.
       from_variant:
@@ -123,7 +123,7 @@ jobs:
           if [ "${{ inputs.from_image }}" == "python" ]; then
             if [ "${{ inputs.container_name }}" == "base" ]; then
               echo "from_image=${{ inputs.from_image }}" >> $GITHUB_OUTPUT
-              echo "from_variant=${{ inputs.python_version }}-slim-trixie" >> $GITHUB_OUTPUT
+              echo "from_variant=${{ inputs.python_version }}-slim-bookworm" >> $GITHUB_OUTPUT
             else
               echo "from_image=ghcr.io/${{ github.repository }}/base" >> $GITHUB_OUTPUT
               echo "from_variant=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Change Summary

The recent change from bullseye to trixie failed, due to Moby package that is not yet available in many debian distributions including the official Python image.
Our long term target is still trixie. #6656 to track. However this will require better planning and testing.
Reverting back to bullseye is not possible due to lack of 3.14 support.
Switching to bookworm as the workaround to unblock 3.14 builds.
