### PR TITLE
Fix(eos_designs): Address template values being None for custom template for ansible-core >= 2.19

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/ansible_only/custom_templates/empty.j2
+++ b/ansible_collections/arista/avd/extensions/molecule/ansible_only/custom_templates/empty.j2
@@ -1,0 +1,8 @@
+{# 
+  This template is used to test the output of custom templates before the
+  when the generated output is empty.
+  The behavior changed between ansible-core <2.19 and >=2.19
+#}
+{% if not_defined is arista.avd.defined %}
+{% endif %}
+

--- a/ansible_collections/arista/avd/extensions/molecule/ansible_only/custom_templates/empty.j2
+++ b/ansible_collections/arista/avd/extensions/molecule/ansible_only/custom_templates/empty.j2
@@ -1,6 +1,5 @@
 {# 
-  This template is used to test the output of custom templates before the
-  when the generated output is empty.
+  This template is used to test the output of custom template when the generated output is empty.
   The behavior changed between ansible-core <2.19 and >=2.19
 #}
 {% if not_defined is arista.avd.defined %}

--- a/ansible_collections/arista/avd/extensions/molecule/ansible_only/inventory/group_vars/CUSTOM_TEMPLATES_SPINES.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/ansible_only/inventory/group_vars/CUSTOM_TEMPLATES_SPINES.yml
@@ -12,3 +12,11 @@ spine:
     - name: custom-templates-spine1
       id: 1
       mgmt_ip: 192.168.200.101/24
+
+# Test custom template that produces empty output which behaves
+# differently in ansible-core <2.19 and ansible-core >=2.19
+eos_designs_custom_templates:
+  - template: custom_templates/empty.j2
+    options:
+      list_merge: append_rp
+      strip_empty_keys: false

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_structured_config.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_structured_config.py
@@ -125,6 +125,10 @@ class ActionModule(ActionBase):
                 # Here we parse the template, expecting the result to be a YAML formatted string
                 template_result = templater(template, template_vars, self.templar)
 
+                # Skip if template result is None or empty string
+                if not template_result:
+                    continue
+
                 # Load data from the template result.
                 template_result_data = yaml.safe_load(template_result)
 


### PR DESCRIPTION
## Change Summary

For ansible-core>=2.19, empty templates can now return None when they used to return ""
https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html#example-unintentional-none-result

This causes issue for users upgrading to ansible-core >= 2.19 with templates rendering None as we are not catching this in the code (and not testing for it)

## Related Issue(s)

Reported in the field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

If the return from the template is None, we should skip it.

## How to test

* Molecule test failing in first commit
* Fix in the second commit 

## Checklist

# User Checklist

- [x] Check if this happen also in eos_cli_config_gen custom templates
    _This author checked and we are safe there, only strings, strings everywhere_

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
