### PR TITLE
Fix(cv_deploy): Use standard 600s timeout for get_tags and delete_tags calls

### DIFF
--- a/python-avd/pyavd/_cv/client/tag.py
+++ b/python-avd/pyavd/_cv/client/tag.py
@@ -63,7 +63,7 @@ class TagMixin(Protocol):
         element_type: Literal["device", "interface"] | None = None,
         creator_type: Literal["user", "system", "external"] | None = None,
         time: datetime | None = None,
-        timeout: float = 30.0,
+        timeout: float = DEFAULT_API_TIMEOUT,
     ) -> list[Tag]:
         """
         Get Tags using arista.tag.v2.TagServiceStub.GetAll arista.tag.v2.TagConfigServiceStub.GetAll APIs.
@@ -261,7 +261,7 @@ class TagMixin(Protocol):
         self: CVClientProtocol,
         workspace_id: str,
         tag_assignments: set[CVTagAssignment],
-        timeout: float = 30.0,
+        timeout: float = DEFAULT_API_TIMEOUT,
     ) -> list[TagAssignmentKey]:
         """
         Set Tags using arista.tag.v2.TagAssignmentConfigServiceStub.SetSome API.


### PR DESCRIPTION
## Change Summary

Use standard 600s timeout for get_tags and delete_tags calls

## Related Issue(s)

Fixes aristanetworks/avd-internal#385

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
Use standard `DEFAULT_API_TIMEOUT` instead of current `30s` to match CV's default timeout for these calls

## How to test
N/A

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
