### PR TITLE
Feat(eos_cli_config_gen, eos_designs): Add ipv6_nd support to vlan_interfaces 

### DIFF
--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7145,6 +7145,7 @@ interface Tunnel4
 | Vlan337 | v4 dhcp relay all-subnets | default | - | - |
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
 | Vlan339 | v6 nd options | default | - | - |
+| Vlan340 | v6 nd new structure | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -7194,6 +7195,7 @@ interface Tunnel4
 | Vlan337 | default | 10.0.2.2/25 | - | - | - | - |
 | Vlan338 | default | - | - | - | - | - |
 | Vlan339 | default | - | - | - | - | - |
+| Vlan340 | default | - | - | - | - | - |
 | Vlan501 | default | 10.50.26.29/27 | - | - | - | - |
 | Vlan667 | default | 192.0.2.2/25 | - | - | - | - |
 | Vlan1001 | Tenant_A | - | 10.1.1.1/24 | - | - | - |
@@ -7230,25 +7232,26 @@ interface Tunnel4
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | True | - | - | - |
-| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - |
-| Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - |
-| Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - |
-| Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | True | - | - | - |
-| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64, fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - |
-| Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | True | - | - | - |
-| Vlan333 | default | 2001:db8:333::2/64 | - | - | - | - | - | - | - |
-| Vlan334 | default | 2001:db8:334::1/64 | - | - | - | - | - | - | - |
-| Vlan335 | default | 2001:db8:335::1/64 | - | - | - | - | - | - | - |
-| Vlan336 | default | 2001:db8:336::1/64 | - | - | - | - | - | - | - |
-| Vlan338 | default | 2001:db8:338::1/64 | - | - | - | - | - | - | - |
-| Vlan339 | default | 2001:db8:339::1/64 | - | - | - | - | True | - | - |
-| Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | True | - | - | - | - |
-| Vlan667 | default | 2001:db8:667::2/64 | - | - | - | - | - | - | - |
-| Vlan1001 | Tenant_A | a1::1/64 | - | - | - | True | - | - | - |
-| Vlan1002 | Tenant_A | a2::1/64 | - | - | True | True | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - | - |
+| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - | - |
+| Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - | - |
+| Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - | - |
+| Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - | - |
+| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64, fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - | - |
+| Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - | - |
+| Vlan333 | default | 2001:db8:333::2/64 | - | - | - | - | - | - | - | - |
+| Vlan334 | default | 2001:db8:334::1/64 | - | - | - | - | - | - | - | - |
+| Vlan335 | default | 2001:db8:335::1/64 | - | - | - | - | - | - | - | - |
+| Vlan336 | default | 2001:db8:336::1/64 | - | - | - | - | - | - | - | - |
+| Vlan338 | default | 2001:db8:338::1/64 | - | - | - | - | - | - | - | - |
+| Vlan339 | default | 2001:db8:339::1/64 | - | - | - | - | - | True | - | - |
+| Vlan340 | default | 2001:db8:340::1/64 | - | - | True | default-route, route-preference | True | True | - | - |
+| Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | True | - | - | - | - | - |
+| Vlan667 | default | 2001:db8:667::2/64 | - | - | - | - | - | - | - | - |
+| Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | True | - | - | - |
+| Vlan1002 | Tenant_A | a2::1/64 | - | - | True | - | True | - | - | - |
 
 ##### VRRP Details
 
@@ -7595,6 +7598,20 @@ interface Vlan339
    ipv6 enable
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
+!
+interface Vlan340
+   description v6 nd new structure
+   ipv6 nd cache expire 300
+   ipv6 nd cache dynamic capacity 1000
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:340::1/64
+   ipv6 nd ra rx accept default-route
+   ipv6 nd ra rx accept route-preference
+   ipv6 nd ra disabled
+   ipv6 nd managed-config-flag
+   ipv6 nd other-config-flag
+   ipv6 nd prefix 2001:db8:340::/64 100 50 no-autoconfig
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4389,6 +4389,20 @@ interface Vlan339
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
 !
+interface Vlan340
+   description v6 nd new structure
+   ipv6 nd cache expire 300
+   ipv6 nd cache dynamic capacity 1000
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:340::1/64
+   ipv6 nd ra rx accept default-route
+   ipv6 nd ra rx accept route-preference
+   ipv6 nd ra disabled
+   ipv6 nd managed-config-flag
+   ipv6 nd other-config-flag
+   ipv6 nd prefix 2001:db8:340::/64 100 50 no-autoconfig
+!
 interface Vlan501
    description SVI Description
    no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -744,3 +744,26 @@ vlan_interfaces:
       dynamic_capacity: 900
       expire: 250
       refresh_always: true
+
+  - name: Vlan340
+    description: v6 nd new structure
+    ipv6_enable: true
+    ipv6_addresses:
+      - 2001:db8:340::1/64
+    ipv6_nd:
+      ra:
+        disabled: true
+        rx_accept:
+          default_route: true
+          route_preference: true
+      managed_config_flag: true
+      other_config_flag: true
+      cache:
+        dynamic_capacity: 1000
+        expire: 300
+        refresh_always: true
+      prefixes:
+        - ipv6_prefix: 2001:db8:340::/64
+          valid_lifetime: 100
+          preferred_lifetime: 50
+          no_autoconfig_flag: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -422,7 +422,9 @@ vlan_interfaces:
     ip_address: 10.50.26.29/27
     ipv6_addresses:
       - 1b11:3a00:22b0:0088::207/127
-    ipv6_nd_ra_disabled: true
+    ipv6_nd:
+      ra:
+        disabled: true
 
   - name: Vlan1001
     description: SVI Description
@@ -431,12 +433,13 @@ vlan_interfaces:
     ip_address_virtual: 10.1.1.1/24
     ipv6_addresses:
       - a1::1/64
-    ipv6_nd_managed_config_flag: true
-    ipv6_nd_prefixes:
-      - ipv6_prefix: a1::/64
-        valid_lifetime: infinite
-        preferred_lifetime: infinite
-        no_autoconfig_flag: true
+    ipv6_nd:
+      managed_config_flag: true
+      prefixes:
+        - ipv6_prefix: a1::/64
+          valid_lifetime: infinite
+          preferred_lifetime: infinite
+          no_autoconfig_flag: true
 
   - name: Vlan24
     description: SVI Description
@@ -444,12 +447,13 @@ vlan_interfaces:
     ip_address_virtual: 10.10.24.1/24
     ipv6_addresses:
       - 1b11:3a00:22b0:6::15/64
-    ipv6_nd_managed_config_flag: true
-    ipv6_nd_prefixes:
-      - ipv6_prefix: 1b11:3a00:22b0:6::/64
-        valid_lifetime: infinite
-        preferred_lifetime: infinite
-        no_autoconfig_flag: true
+    ipv6_nd:
+      managed_config_flag: true
+      prefixes:
+        - ipv6_prefix: 1b11:3a00:22b0:6::/64
+          valid_lifetime: infinite
+          preferred_lifetime: infinite
+          no_autoconfig_flag: true
     ipv6_virtual_router_addresses:
       - 1b11:3a00:22b0:6::1
 
@@ -492,13 +496,15 @@ vlan_interfaces:
     ip_address_virtual: 10.1.2.1/24
     ipv6_addresses:
       - a2::1/64
-    ipv6_nd_managed_config_flag: true
-    ipv6_nd_prefixes:
-      - ipv6_prefix: a2::/64
-        valid_lifetime: infinite
-        preferred_lifetime: infinite
-        no_autoconfig_flag: true
-    ipv6_nd_ra_disabled: true
+    ipv6_nd:
+      managed_config_flag: true
+      prefixes:
+        - ipv6_prefix: a2::/64
+          valid_lifetime: infinite
+          preferred_lifetime: infinite
+          no_autoconfig_flag: true
+      ra:
+        disabled: true
 
   - name: Vlan75
     description: SVI Description
@@ -506,12 +512,13 @@ vlan_interfaces:
     ip_address_virtual: 10.10.75.1/24
     ipv6_addresses:
       - 1b11:3a00:22b0:1000::15/64
-    ipv6_nd_managed_config_flag: true
-    ipv6_nd_prefixes:
-      - ipv6_prefix: 1b11:3a00:22b0:1000::/64
-        valid_lifetime: infinite
-        preferred_lifetime: infinite
-        no_autoconfig_flag: true
+    ipv6_nd:
+      managed_config_flag: true
+      prefixes:
+        - ipv6_prefix: 1b11:3a00:22b0:1000::/64
+          valid_lifetime: infinite
+          preferred_lifetime: infinite
+          no_autoconfig_flag: true
     ipv6_virtual_router_addresses:
       - 1b11:3a00:22b0:1000::1
     multicast:
@@ -537,12 +544,13 @@ vlan_interfaces:
     ip_address_virtual: 10.10.144.3/20
     ipv6_addresses:
       - 1b11:3a00:22b0:5200::15/64
-    ipv6_nd_managed_config_flag: true
-    ipv6_nd_prefixes:
-      - ipv6_prefix: 1b11:3a00:22b0:5200::/64
-        valid_lifetime: infinite
-        preferred_lifetime: infinite
-        no_autoconfig_flag: true
+    ipv6_nd:
+      managed_config_flag: true
+      prefixes:
+        - ipv6_prefix: 1b11:3a00:22b0:5200::/64
+          valid_lifetime: infinite
+          preferred_lifetime: infinite
+          no_autoconfig_flag: true
     ipv6_virtual_router_addresses:
       - 1b11:3a00:22b0:5200::3
     ip_helpers:
@@ -739,11 +747,12 @@ vlan_interfaces:
     ipv6_enable: true
     ipv6_addresses:
       - 2001:db8:339::1/64
-    ipv6_nd_other_config_flag: true
-    ipv6_nd_cache:
-      dynamic_capacity: 900
-      expire: 250
-      refresh_always: true
+    ipv6_nd:
+      other_config_flag: true
+      cache:
+        dynamic_capacity: 900
+        expire: 250
+        refresh_always: true
 
   - name: Vlan340
     description: v6 nd new structure

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -240,18 +240,21 @@ interface Tunnel1
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | VLAN10 | Test_ipv6_address | default | - | - |
+| VLAN20 | Test_ipv6_nd_deprecated | default | - | - |
 
 ##### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ------ | ------- |
 | VLAN10 | default | 10.2.255.3/32 | - | - | - | - |
+| VLAN20 | default | - | - | - | - | - |
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
-| VLAN10 | default | 2002::CAFE/128 | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| VLAN10 | default | 2002::CAFE/128 | - | - | - | - | - | - | - | - |
+| VLAN20 | default | 2001:db8:20::1/64 | - | - | True | - | True | True | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -261,4 +264,16 @@ interface VLAN10
    description Test_ipv6_address
    ip address 10.2.255.3/32
    ipv6 address 2002::CAFE/128
+!
+interface VLAN20
+   description Test_ipv6_nd_deprecated
+   ipv6 nd cache expire 200
+   ipv6 nd cache dynamic capacity 800
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:20::1/64
+   ipv6 nd ra disabled
+   ipv6 nd managed-config-flag
+   ipv6 nd other-config-flag
+   ipv6 nd prefix 2001:db8:20::/64 infinite infinite no-autoconfig
 ```

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -240,7 +240,7 @@ interface Tunnel1
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | VLAN10 | Test_ipv6_address | default | - | - |
-| VLAN20 | Test_ipv6_nd_deprecated | default | - | - |
+| VLAN20 | - | default | - | - |
 
 ##### IPv4
 
@@ -254,7 +254,6 @@ interface Tunnel1
 | Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
 | VLAN10 | default | 2002::CAFE/128 | - | - | - | - | - | - | - | - |
-| VLAN20 | default | 2001:db8:20::1/64 | - | - | True | - | True | True | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -266,12 +265,9 @@ interface VLAN10
    ipv6 address 2002::CAFE/128
 !
 interface VLAN20
-   description Test_ipv6_nd_deprecated
    ipv6 nd cache expire 200
    ipv6 nd cache dynamic capacity 800
    ipv6 nd cache refresh always
-   ipv6 enable
-   ipv6 address 2001:db8:20::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd other-config-flag

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -34,6 +34,18 @@ interface VLAN10
    ip address 10.2.255.3/32
    ipv6 address 2002::CAFE/128
 !
+interface VLAN20
+   description Test_ipv6_nd_deprecated
+   ipv6 nd cache expire 200
+   ipv6 nd cache dynamic capacity 800
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:20::1/64
+   ipv6 nd ra disabled
+   ipv6 nd managed-config-flag
+   ipv6 nd other-config-flag
+   ipv6 nd prefix 2001:db8:20::/64 infinite infinite no-autoconfig
+!
 ip radius vrf default source-interface Loopback1
 ip radius source-interface Loopback10
 ip radius vrf MGMT source-interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -35,12 +35,9 @@ interface VLAN10
    ipv6 address 2002::CAFE/128
 !
 interface VLAN20
-   description Test_ipv6_nd_deprecated
    ipv6 nd cache expire 200
    ipv6 nd cache dynamic capacity 800
    ipv6 nd cache refresh always
-   ipv6 enable
-   ipv6 address 2001:db8:20::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd other-config-flag

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/vlan-interfaces.yml
@@ -8,10 +8,6 @@ vlan_interfaces:
 
   # Test for deprecated keys ipv6_nd_ra_disabled, ipv6_nd_managed_config_flag, ipv6_nd_prefixes, ipv6_nd_other_config_flag, ipv6_nd_cache
   - name: VLAN20
-    description: Test_ipv6_nd_deprecated
-    ipv6_enable: true
-    ipv6_addresses:
-      - 2001:db8:20::1/64
     ipv6_nd_ra_disabled: true
     ipv6_nd_managed_config_flag: true
     ipv6_nd_other_config_flag: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/vlan-interfaces.yml
@@ -5,3 +5,22 @@ vlan_interfaces:
     description: Test_ipv6_address
     ip_address: 10.2.255.3/32
     ipv6_address: 2002::CAFE/128
+
+  # Test for deprecated keys ipv6_nd_ra_disabled, ipv6_nd_managed_config_flag, ipv6_nd_prefixes, ipv6_nd_other_config_flag, ipv6_nd_cache
+  - name: VLAN20
+    description: Test_ipv6_nd_deprecated
+    ipv6_enable: true
+    ipv6_addresses:
+      - 2001:db8:20::1/64
+    ipv6_nd_ra_disabled: true
+    ipv6_nd_managed_config_flag: true
+    ipv6_nd_other_config_flag: true
+    ipv6_nd_cache:
+      dynamic_capacity: 800
+      expire: 200
+      refresh_always: true
+    ipv6_nd_prefixes:
+      - ipv6_prefix: 2001:db8:20::/64
+        valid_lifetime: infinite
+        preferred_lifetime: infinite
+        no_autoconfig_flag: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-leaf2a.yml
@@ -1339,16 +1339,17 @@ vlan_interfaces:
   - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
-  ipv6_nd_prefixes:
-  - ipv6_prefix: 2001:db8:310::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:311::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:312::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
+  ipv6_nd:
+    prefixes:
+    - ipv6_prefix: 2001:db8:310::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:311::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:312::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
   metadata:
     tenants:
     - Tenant_D

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-leaf2b.yml
@@ -1220,16 +1220,17 @@ vlan_interfaces:
   - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
-  ipv6_nd_prefixes:
-  - ipv6_prefix: 2001:db8:310::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:311::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:312::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
+  ipv6_nd:
+    prefixes:
+    - ipv6_prefix: 2001:db8:310::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:311::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:312::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
   metadata:
     tenants:
     - Tenant_D

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-services-l2-only-false.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-services-l2-only-false.yml
@@ -880,16 +880,17 @@ vlan_interfaces:
   - 2001:db8:310::1/64
   - 2001:db8:311::1/64
   - 2001:db8:312::1/64
-  ipv6_nd_prefixes:
-  - ipv6_prefix: 2001:db8:310::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:311::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
-  - ipv6_prefix: 2001:db8:312::1/64
-    valid_lifetime: '200'
-    preferred_lifetime: '100'
+  ipv6_nd:
+    prefixes:
+    - ipv6_prefix: 2001:db8:310::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:311::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
+    - ipv6_prefix: 2001:db8:312::1/64
+      valid_lifetime: '200'
+      preferred_lifetime: '100'
   metadata:
     tenants:
     - Tenant_D

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -98,14 +98,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_link_local</samp>](## "vlan_interfaces.[].ipv6_address_link_local") | String |  |  |  | IPv6_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_virtual_router_addresses</samp>](## "vlan_interfaces.[].ipv6_virtual_router_addresses") | List, items: String |  |  |  | Improved "VARPv6" data model to support multiple VARPv6 addresses. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlan_interfaces.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6 address or IPv6_address/Mask. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "vlan_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_other_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_other_config_flag") | Boolean |  |  |  | Set the "other stateful configuration" flag in IPv6 router advertisements. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_cache</samp>](## "vlan_interfaces.[].ipv6_nd_cache") | Dictionary |  |  |  | IPv6 neighbor cache options. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "vlan_interfaces.[].ipv6_nd_ra_disabled") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>ipv6_nd.ra.disabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_managed_config_flag") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>ipv6_nd.managed_config_flag</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_other_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_other_config_flag") <span style="color:red">deprecated</span> | Boolean |  |  |  | Set the "other stateful configuration" flag in IPv6 router advertisements.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>ipv6_nd.other_config_flag</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_cache</samp>](## "vlan_interfaces.[].ipv6_nd_cache") <span style="color:red">deprecated</span> | Dictionary |  |  |  | IPv6 neighbor cache options.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>ipv6_nd.cache</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic_capacity</samp>](## "vlan_interfaces.[].ipv6_nd_cache.dynamic_capacity") | Integer |  |  | Min: 0<br>Max: 4294967295 | Capacity of dynamic cache entries. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expire</samp>](## "vlan_interfaces.[].ipv6_nd_cache.expire") | Integer |  |  | Min: 1<br>Max: 65535 | Cache entries expirery in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;refresh_always</samp>](## "vlan_interfaces.[].ipv6_nd_cache.refresh_always") | Boolean |  |  |  | Force refresh on cache expiry. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes") <span style="color:red">deprecated</span> | List, items: Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>ipv6_nd.prefixes</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ipv6_prefix</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  | IPv6_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | In seconds <0-4294967295> or infinite. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes.[].preferred_lifetime") | String |  |  |  | In seconds <0-4294967295> or infinite. |
@@ -117,6 +117,23 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "vlan_interfaces.[].ipv6_dhcp_relay_destinations.[].source_address") | String |  |  |  | Source IPv6 address to communicate with DHCP server - mutually exclusive to local_interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;link_address</samp>](## "vlan_interfaces.[].ipv6_dhcp_relay_destinations.[].link_address") | String |  |  |  | Override the default link address specified in the relayed DHCP packet. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_dhcp_relay_all_subnets</samp>](## "vlan_interfaces.[].ipv6_dhcp_relay_all_subnets") | Boolean |  |  |  | Allow forwarding requests with additional IPv6 addresses in the gateway address "giaddr" field. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd</samp>](## "vlan_interfaces.[].ipv6_nd") | Dictionary |  |  |  | IPv6 Neighbor Discovery protocol. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd.other_config_flag") | Boolean |  |  |  | Set the "other stateful configuration" flag in IPv6 router advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cache</samp>](## "vlan_interfaces.[].ipv6_nd.cache") | Dictionary |  |  |  | IPv6 neighbor cache options. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic_capacity</samp>](## "vlan_interfaces.[].ipv6_nd.cache.dynamic_capacity") | Integer |  |  | Min: 0<br>Max: 4294967295 | Capacity of dynamic cache entries. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expire</samp>](## "vlan_interfaces.[].ipv6_nd.cache.expire") | Integer |  |  | Min: 1<br>Max: 65535 | Cache entries expirery in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;refresh_always</samp>](## "vlan_interfaces.[].ipv6_nd.cache.refresh_always") | Boolean |  |  |  | Force refresh on cache expiry. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ra</samp>](## "vlan_interfaces.[].ipv6_nd.ra") | Dictionary |  |  |  | Router Advertisement. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "vlan_interfaces.[].ipv6_nd.ra.disabled") | Boolean |  |  |  | Disable Router Advertisement messages on the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_accept</samp>](## "vlan_interfaces.[].ipv6_nd.ra.rx_accept") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_route</samp>](## "vlan_interfaces.[].ipv6_nd.ra.rx_accept.default_route") | Boolean |  |  |  | Accept default route from received Router Advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_preference</samp>](## "vlan_interfaces.[].ipv6_nd.ra.rx_accept.route_preference") | Boolean |  |  |  | Accept route preference from received Router Advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;managed_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd.managed_config_flag") | Boolean |  |  |  | Set the "Managed Address Configuration" (M) flag in Router Advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefixes</samp>](## "vlan_interfaces.[].ipv6_nd.prefixes") | List, items: Dictionary |  |  |  | IPv6 prefixes to include in Router Advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ipv6_prefix</samp>](## "vlan_interfaces.[].ipv6_nd.prefixes.[].ipv6_prefix") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "vlan_interfaces.[].ipv6_nd.prefixes.[].valid_lifetime") | String |  |  |  | Valid lifetime in seconds '<0-4294967295>' or 'infinite'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preferred_lifetime</samp>](## "vlan_interfaces.[].ipv6_nd.prefixes.[].preferred_lifetime") | String |  |  |  | Preferred lifetime in seconds '<0-4294967295>' or 'infinite'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;no_autoconfig_flag</samp>](## "vlan_interfaces.[].ipv6_nd.prefixes.[].no_autoconfig_flag") | Boolean |  |  |  | Indicate that the prefix cannot be used for stateless address autoconfiguration (SLAAC). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "vlan_interfaces.[].access_group_in") | String |  |  |  | IPv4 access-list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "vlan_interfaces.[].access_group_out") | String |  |  |  | IPv4 access-list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_group_in</samp>](## "vlan_interfaces.[].ipv6_access_group_in") | String |  |  |  | IPv6 access-list name. |
@@ -469,13 +486,25 @@
 
             # IPv6 address or IPv6_address/Mask.
           - <str>
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `ipv6_nd.ra.disabled` instead.
         ipv6_nd_ra_disabled: <bool>
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `ipv6_nd.managed_config_flag` instead.
         ipv6_nd_managed_config_flag: <bool>
 
         # Set the "other stateful configuration" flag in IPv6 router advertisements.
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `ipv6_nd.other_config_flag` instead.
         ipv6_nd_other_config_flag: <bool>
 
         # IPv6 neighbor cache options.
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `ipv6_nd.cache` instead.
         ipv6_nd_cache:
 
           # Capacity of dynamic cache entries.
@@ -486,6 +515,9 @@
 
           # Force refresh on cache expiry.
           refresh_always: <bool>
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `ipv6_nd.prefixes` instead.
         ipv6_nd_prefixes:
 
             # IPv6_address/Mask.
@@ -514,6 +546,53 @@
 
         # Allow forwarding requests with additional IPv6 addresses in the gateway address "giaddr" field.
         ipv6_dhcp_relay_all_subnets: <bool>
+
+        # IPv6 Neighbor Discovery protocol.
+        ipv6_nd:
+
+          # Set the "other stateful configuration" flag in IPv6 router advertisements.
+          other_config_flag: <bool>
+
+          # IPv6 neighbor cache options.
+          cache:
+
+            # Capacity of dynamic cache entries.
+            dynamic_capacity: <int; 0-4294967295>
+
+            # Cache entries expirery in seconds.
+            expire: <int; 1-65535>
+
+            # Force refresh on cache expiry.
+            refresh_always: <bool>
+
+          # Router Advertisement.
+          ra:
+
+            # Disable Router Advertisement messages on the interface.
+            disabled: <bool>
+            rx_accept:
+
+              # Accept default route from received Router Advertisements.
+              default_route: <bool>
+
+              # Accept route preference from received Router Advertisements.
+              route_preference: <bool>
+
+          # Set the "Managed Address Configuration" (M) flag in Router Advertisements.
+          managed_config_flag: <bool>
+
+          # IPv6 prefixes to include in Router Advertisements.
+          prefixes:
+            - ipv6_prefix: <str; required; unique>
+
+              # Valid lifetime in seconds '<0-4294967295>' or 'infinite'.
+              valid_lifetime: <str>
+
+              # Preferred lifetime in seconds '<0-4294967295>' or 'infinite'.
+              preferred_lifetime: <str>
+
+              # Indicate that the prefix cannot be used for stateless address autoconfiguration (SLAAC).
+              no_autoconfig_flag: <bool>
 
         # IPv4 access-list name.
         access_group_in: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -121,7 +121,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;other_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd.other_config_flag") | Boolean |  |  |  | Set the "other stateful configuration" flag in IPv6 router advertisements. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cache</samp>](## "vlan_interfaces.[].ipv6_nd.cache") | Dictionary |  |  |  | IPv6 neighbor cache options. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic_capacity</samp>](## "vlan_interfaces.[].ipv6_nd.cache.dynamic_capacity") | Integer |  |  | Min: 0<br>Max: 4294967295 | Capacity of dynamic cache entries. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expire</samp>](## "vlan_interfaces.[].ipv6_nd.cache.expire") | Integer |  |  | Min: 1<br>Max: 65535 | Cache entries expirery in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expire</samp>](## "vlan_interfaces.[].ipv6_nd.cache.expire") | Integer |  |  | Min: 1<br>Max: 65535 | Cache entries expiry in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;refresh_always</samp>](## "vlan_interfaces.[].ipv6_nd.cache.refresh_always") | Boolean |  |  |  | Force refresh on cache expiry. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ra</samp>](## "vlan_interfaces.[].ipv6_nd.ra") | Dictionary |  |  |  | Router Advertisement. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "vlan_interfaces.[].ipv6_nd.ra.disabled") | Boolean |  |  |  | Disable Router Advertisement messages on the interface. |
@@ -559,7 +559,7 @@
             # Capacity of dynamic cache entries.
             dynamic_capacity: <int; 0-4294967295>
 
-            # Cache entries expirery in seconds.
+            # Cache entries expiry in seconds.
             expire: <int; 1-65535>
 
             # Force refresh on cache expiry.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -69,8 +69,8 @@
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | ------------------- | ----------------- | ----------- | ------------ |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
 {%         for vlan_interface in vlan_interfaces_ipv6 | arista.avd.natural_sort('name') %}
 {%             set row_vrf = vlan_interface.vrf | arista.avd.default('default') %}
 {%             if vlan_interface.ipv6_addresses is arista.avd.defined %}
@@ -84,12 +84,30 @@
 {%             endif %}
 {%             set row_ip_vaddr = vlan_interface.ipv6_address_virtuals | arista.avd.default('-') | join(", ") %}
 {%             set row_varp = vlan_interface.ipv6_virtual_router_addresses | arista.avd.default('-') | join(", ") %}
-{%             set row_nd_ra_disabled = vlan_interface.ipv6_nd_ra_disabled | arista.avd.default('-') %}
-{%             set row_nd_man_cfg = vlan_interface.ipv6_nd_managed_config_flag | arista.avd.default('-') %}
-{%             set row_nd_oth_cfg = vlan_interface.ipv6_nd_other_config_flag | arista.avd.default('-') %}
+{%             set row_nd_ra_disabled = vlan_interface.ipv6_nd.ra.disabled | arista.avd.default(vlan_interface.ipv6_nd_ra_disabled, "-") %}
+{%             if vlan_interface.ipv6_nd.managed_config_flag is arista.avd.defined %}
+{%                 set row_nd_man_cfg = vlan_interface.ipv6_nd.managed_config_flag %}
+{%             elif vlan_interface.ipv6_nd_managed_config_flag is arista.avd.defined %}
+{%                 set row_nd_man_cfg = vlan_interface.ipv6_nd_managed_config_flag %}
+{%             else %}
+{%                 set row_nd_man_cfg = '-' %}
+{%             endif %}
+{%             set nd_ra_rx_accept = [] %}
+{%             if vlan_interface.ipv6_nd.ra.rx_accept.default_route is arista.avd.defined(true) %}
+{%                 do nd_ra_rx_accept.append("default-route") %}
+{%             endif %}
+{%             if vlan_interface.ipv6_nd.ra.rx_accept.route_preference is arista.avd.defined(true) %}
+{%                 do nd_ra_rx_accept.append("route-preference") %}
+{%             endif %}
+{%             if nd_ra_rx_accept %}
+{%                 set nd_ra_rx_accept = nd_ra_rx_accept | join(", ") %}
+{%             else %}
+{%                 set nd_ra_rx_accept = "-" %}
+{%             endif %}
+{%             set row_nd_oth_cfg = vlan_interface.ipv6_nd.other_config_flag | arista.avd.default(vlan_interface.ipv6_nd_other_config_flag, "-") %}
 {%             set row_acl_in = vlan_interface.ipv6_access_group_in | arista.avd.default('-') %}
 {%             set row_acl_out = vlan_interface.ipv6_access_group_out | arista.avd.default('-') %}
-| {{ vlan_interface.name }} | {{ row_vrf }} | {{ row_ipv6_address }} | {{ row_ip_vaddr }} | {{ row_varp }} | {{ row_nd_ra_disabled }} | {{ row_nd_man_cfg }} | {{ row_nd_oth_cfg }} | {{ row_acl_in }} | {{ row_acl_out }} |
+| {{ vlan_interface.name }} | {{ row_vrf }} | {{ row_ipv6_address }} | {{ row_ip_vaddr }} | {{ row_varp }} | {{ row_nd_ra_disabled }} | {{ nd_ra_rx_accept }} | {{ row_nd_man_cfg }} | {{ row_nd_oth_cfg }} | {{ row_acl_in }} | {{ row_acl_out }} |
 {%         endfor %}
 {%     endif %}
 {# VRRP #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -85,13 +85,7 @@
 {%             set row_ip_vaddr = vlan_interface.ipv6_address_virtuals | arista.avd.default('-') | join(", ") %}
 {%             set row_varp = vlan_interface.ipv6_virtual_router_addresses | arista.avd.default('-') | join(", ") %}
 {%             set row_nd_ra_disabled = vlan_interface.ipv6_nd.ra.disabled | arista.avd.default(vlan_interface.ipv6_nd_ra_disabled, "-") %}
-{%             if vlan_interface.ipv6_nd.managed_config_flag is arista.avd.defined %}
-{%                 set row_nd_man_cfg = vlan_interface.ipv6_nd.managed_config_flag %}
-{%             elif vlan_interface.ipv6_nd_managed_config_flag is arista.avd.defined %}
-{%                 set row_nd_man_cfg = vlan_interface.ipv6_nd_managed_config_flag %}
-{%             else %}
-{%                 set row_nd_man_cfg = '-' %}
-{%             endif %}
+{%             set row_nd_man_cfg = vlan_interface.ipv6_nd.managed_config_flag | arista.avd.default( vlan_interface.ipv6_nd_managed_config_flag, "-") %}
 {%             set nd_ra_rx_accept = [] %}
 {%             if vlan_interface.ipv6_nd.ra.rx_accept.default_route is arista.avd.defined(true) %}
 {%                 do nd_ra_rx_accept.append("default-route") %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -65,10 +65,10 @@ interface {{ vlan_interface.name }}
    arp cache dynamic capacity {{ vlan_interface.arp_cache_dynamic_capacity }}
 {%     endif %}
 {%     set ipv6_nd_cache = vlan_interface.ipv6_nd.cache | arista.avd.default(vlan_interface.ipv6_nd_cache) %}
-{%     if ipv6_nd_cache.expire is arista.avd.defined() %}
+{%     if ipv6_nd_cache.expire is arista.avd.defined %}
    ipv6 nd cache expire {{ ipv6_nd_cache.expire }}
 {%     endif %}
-{%     if ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
+{%     if ipv6_nd_cache.dynamic_capacity is arista.avd.defined %}
    ipv6 nd cache dynamic capacity {{ ipv6_nd_cache.dynamic_capacity }}
 {%     endif %}
 {%     if vlan_interface.arp_monitor_mac_address is arista.avd.defined(true) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -64,16 +64,17 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.arp_cache_dynamic_capacity is arista.avd.defined %}
    arp cache dynamic capacity {{ vlan_interface.arp_cache_dynamic_capacity }}
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_cache.expire is arista.avd.defined() %}
-   ipv6 nd cache expire {{ vlan_interface.ipv6_nd_cache.expire }}
+{%     set ipv6_nd_cache = vlan_interface.ipv6_nd.cache | arista.avd.default(vlan_interface.ipv6_nd_cache) %}
+{%     if ipv6_nd_cache.expire is arista.avd.defined() %}
+   ipv6 nd cache expire {{ ipv6_nd_cache.expire }}
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
-   ipv6 nd cache dynamic capacity {{ vlan_interface.ipv6_nd_cache.dynamic_capacity }}
+{%     if ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
+   ipv6 nd cache dynamic capacity {{ ipv6_nd_cache.dynamic_capacity }}
 {%     endif %}
 {%     if vlan_interface.arp_monitor_mac_address is arista.avd.defined(true) %}
    arp monitor mac-address
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_cache.refresh_always is arista.avd.defined(true) %}
+{%     if ipv6_nd_cache.refresh_always is arista.avd.defined(true) %}
    ipv6 nd cache refresh always
 {%     endif %}
 {%     if vlan_interface.bfd.interval is arista.avd.defined and
@@ -202,30 +203,35 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interface.ipv6_address_link_local }} link-local
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
+{%     if vlan_interface.ipv6_nd.ra.rx_accept.default_route is arista.avd.defined(true) %}
+   ipv6 nd ra rx accept default-route
+{%     endif %}
+{%     if vlan_interface.ipv6_nd.ra.rx_accept.route_preference is arista.avd.defined(true) %}
+   ipv6 nd ra rx accept route-preference
+{%     endif %}
+{%     if vlan_interface.ipv6_nd.ra.disabled is arista.avd.defined(true) or vlan_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
+{%     if vlan_interface.ipv6_nd.managed_config_flag is arista.avd.defined(true) or vlan_interface.ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_other_config_flag is arista.avd.defined(true) %}
+{%     if vlan_interface.ipv6_nd.other_config_flag is arista.avd.defined(true) or vlan_interface.ipv6_nd_other_config_flag is arista.avd.defined(true) %}
    ipv6 nd other-config-flag
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_prefixes is arista.avd.defined %}
-{%         for prefix in vlan_interface.ipv6_nd_prefixes | arista.avd.natural_sort("ipv6_prefix") %}
-{%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
-{%             if prefix.valid_lifetime is arista.avd.defined %}
-{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
-{%                 if prefix.preferred_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.preferred_lifetime %}
-{%                 endif %}
+{%     set ipv6_nd_prefixes = vlan_interface.ipv6_nd.prefixes | arista.avd.default(vlan_interface.ipv6_nd_prefixes) %}
+{%     for prefix in ipv6_nd_prefixes | arista.avd.natural_sort("ipv6_prefix") %}
+{%         set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
+{%         if prefix.valid_lifetime is arista.avd.defined %}
+{%             set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
+{%             if prefix.preferred_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.preferred_lifetime %}
 {%             endif %}
-{%             if prefix.no_autoconfig_flag is arista.avd.defined(true) %}
-{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
-{%             endif %}
+{%         endif %}
+{%         if prefix.no_autoconfig_flag is arista.avd.defined(true) %}
+{%             set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%         endif %}
    {{ ipv6_nd_prefix_cli }}
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
 {%     if vlan_interface.access_group_in is arista.avd.defined %}
    ip access-group {{ vlan_interface.access_group_in }} in
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -67500,7 +67500,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 dynamic_capacity: int | None
                 """Capacity of dynamic cache entries."""
                 expire: int | None
-                """Cache entries expirery in seconds."""
+                """Cache entries expiry in seconds."""
                 refresh_always: bool | None
                 """Force refresh on cache expiry."""
 
@@ -67521,7 +67521,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         Args:
                             dynamic_capacity: Capacity of dynamic cache entries.
-                            expire: Cache entries expirery in seconds.
+                            expire: Cache entries expiry in seconds.
                             refresh_always: Force refresh on cache expiry.
 
                         """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -67331,6 +67331,207 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         Ipv6DhcpRelayDestinations._item_type = Ipv6DhcpRelayDestinationsItem
 
+        class Ipv6Nd(AvdModel):
+            """Subclass of AvdModel."""
+
+            class Cache(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"dynamic_capacity": {"type": int}, "expire": {"type": int}, "refresh_always": {"type": bool}}
+                dynamic_capacity: int | None
+                """Capacity of dynamic cache entries."""
+                expire: int | None
+                """Cache entries expirery in seconds."""
+                refresh_always: bool | None
+                """Force refresh on cache expiry."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        dynamic_capacity: int | None | UndefinedType = Undefined,
+                        expire: int | None | UndefinedType = Undefined,
+                        refresh_always: bool | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        Cache.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            dynamic_capacity: Capacity of dynamic cache entries.
+                            expire: Cache entries expirery in seconds.
+                            refresh_always: Force refresh on cache expiry.
+
+                        """
+
+            class Ra(AvdModel):
+                """Subclass of AvdModel."""
+
+                class RxAccept(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    _fields: ClassVar[dict] = {"default_route": {"type": bool}, "route_preference": {"type": bool}}
+                    default_route: bool | None
+                    """Accept default route from received Router Advertisements."""
+                    route_preference: bool | None
+                    """Accept route preference from received Router Advertisements."""
+
+                    if TYPE_CHECKING:
+
+                        def __init__(
+                            self, *, default_route: bool | None | UndefinedType = Undefined, route_preference: bool | None | UndefinedType = Undefined
+                        ) -> None:
+                            """
+                            RxAccept.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                default_route: Accept default route from received Router Advertisements.
+                                route_preference: Accept route preference from received Router Advertisements.
+
+                            """
+
+                _fields: ClassVar[dict] = {"disabled": {"type": bool}, "rx_accept": {"type": RxAccept}}
+                disabled: bool | None
+                """Disable Router Advertisement messages on the interface."""
+                rx_accept: RxAccept
+                """Subclass of AvdModel."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, disabled: bool | None | UndefinedType = Undefined, rx_accept: RxAccept | UndefinedType = Undefined) -> None:
+                        """
+                        Ra.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            disabled: Disable Router Advertisement messages on the interface.
+                            rx_accept: Subclass of AvdModel.
+
+                        """
+
+            class PrefixesItem(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {
+                    "ipv6_prefix": {"type": str},
+                    "valid_lifetime": {"type": str},
+                    "preferred_lifetime": {"type": str},
+                    "no_autoconfig_flag": {"type": bool},
+                }
+                ipv6_prefix: str
+                valid_lifetime: str | None
+                """Valid lifetime in seconds '<0-4294967295>' or 'infinite'."""
+                preferred_lifetime: str | None
+                """Preferred lifetime in seconds '<0-4294967295>' or 'infinite'."""
+                no_autoconfig_flag: bool | None
+                """Indicate that the prefix cannot be used for stateless address autoconfiguration (SLAAC)."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        ipv6_prefix: str | UndefinedType = Undefined,
+                        valid_lifetime: str | None | UndefinedType = Undefined,
+                        preferred_lifetime: str | None | UndefinedType = Undefined,
+                        no_autoconfig_flag: bool | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        PrefixesItem.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            ipv6_prefix: ipv6_prefix
+                            valid_lifetime: Valid lifetime in seconds '<0-4294967295>' or 'infinite'.
+                            preferred_lifetime: Preferred lifetime in seconds '<0-4294967295>' or 'infinite'.
+                            no_autoconfig_flag: Indicate that the prefix cannot be used for stateless address autoconfiguration (SLAAC).
+
+                        """
+
+            class Prefixes(AvdIndexedList[str, PrefixesItem]):
+                """Subclass of AvdIndexedList with `PrefixesItem` items. Primary key is `ipv6_prefix` (`str`)."""
+
+                _primary_key: ClassVar[str] = "ipv6_prefix"
+
+            Prefixes._item_type = PrefixesItem
+
+            _fields: ClassVar[dict] = {
+                "other_config_flag": {"type": bool},
+                "cache": {"type": Cache},
+                "ra": {"type": Ra},
+                "managed_config_flag": {"type": bool},
+                "prefixes": {"type": Prefixes},
+            }
+            other_config_flag: bool | None
+            """Set the "other stateful configuration" flag in IPv6 router advertisements."""
+            cache: Cache
+            """
+            IPv6 neighbor cache options.
+
+            Subclass of AvdModel.
+            """
+            ra: Ra
+            """
+            Router Advertisement.
+
+            Subclass of AvdModel.
+            """
+            managed_config_flag: bool | None
+            """Set the "Managed Address Configuration" (M) flag in Router Advertisements."""
+            prefixes: Prefixes
+            """
+            IPv6 prefixes to include in Router Advertisements.
+
+            Subclass of AvdIndexedList with `PrefixesItem`
+            items. Primary key is `ipv6_prefix` (`str`).
+            """
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    other_config_flag: bool | None | UndefinedType = Undefined,
+                    cache: Cache | UndefinedType = Undefined,
+                    ra: Ra | UndefinedType = Undefined,
+                    managed_config_flag: bool | None | UndefinedType = Undefined,
+                    prefixes: Prefixes | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    Ipv6Nd.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        other_config_flag: Set the "other stateful configuration" flag in IPv6 router advertisements.
+                        cache:
+                           IPv6 neighbor cache options.
+
+                           Subclass of AvdModel.
+                        ra:
+                           Router Advertisement.
+
+                           Subclass of AvdModel.
+                        managed_config_flag: Set the "Managed Address Configuration" (M) flag in Router Advertisements.
+                        prefixes:
+                           IPv6 prefixes to include in Router Advertisements.
+
+                           Subclass of AvdIndexedList with `PrefixesItem`
+                           items. Primary key is `ipv6_prefix` (`str`).
+
+                    """
+
         class Multicast(AvdModel):
             """Subclass of AvdModel."""
 
@@ -68898,6 +69099,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "ipv6_nd_prefixes": {"type": Ipv6NdPrefixes},
             "ipv6_dhcp_relay_destinations": {"type": Ipv6DhcpRelayDestinations},
             "ipv6_dhcp_relay_all_subnets": {"type": bool},
+            "ipv6_nd": {"type": Ipv6Nd},
             "access_group_in": {"type": str},
             "access_group_out": {"type": str},
             "ipv6_access_group_in": {"type": str},
@@ -69023,6 +69225,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """
         ipv6_dhcp_relay_all_subnets: bool | None
         """Allow forwarding requests with additional IPv6 addresses in the gateway address "giaddr" field."""
+        ipv6_nd: Ipv6Nd
+        """
+        IPv6 Neighbor Discovery protocol.
+
+        Subclass of AvdModel.
+        """
         access_group_in: str | None
         """IPv4 access-list name."""
         access_group_out: str | None
@@ -69142,6 +69350,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ipv6_nd_prefixes: Ipv6NdPrefixes | UndefinedType = Undefined,
                 ipv6_dhcp_relay_destinations: Ipv6DhcpRelayDestinations | UndefinedType = Undefined,
                 ipv6_dhcp_relay_all_subnets: bool | None | UndefinedType = Undefined,
+                ipv6_nd: Ipv6Nd | UndefinedType = Undefined,
                 access_group_in: str | None | UndefinedType = Undefined,
                 access_group_out: str | None | UndefinedType = Undefined,
                 ipv6_access_group_in: str | None | UndefinedType = Undefined,
@@ -69242,6 +69451,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        Subclass of AvdIndexedList with `Ipv6DhcpRelayDestinationsItem` items. Primary key is `address`
                        (`str`).
                     ipv6_dhcp_relay_all_subnets: Allow forwarding requests with additional IPv6 addresses in the gateway address "giaddr" field.
+                    ipv6_nd:
+                       IPv6 Neighbor Discovery protocol.
+
+                       Subclass of AvdModel.
                     access_group_in: IPv4 access-list name.
                     access_group_out: IPv4 access-list name.
                     ipv6_access_group_in: IPv6 access-list name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -24876,14 +24876,34 @@ keys:
             description: IPv6 address or IPv6_address/Mask.
         ipv6_nd_ra_disabled:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.ra.disabled
+            removed: false
+            remove_in_version: 7.0.0
         ipv6_nd_managed_config_flag:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.managed_config_flag
+            removed: false
+            remove_in_version: 7.0.0
         ipv6_nd_other_config_flag:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.other_config_flag
+            removed: false
+            remove_in_version: 7.0.0
           description: Set the "other stateful configuration" flag in IPv6 router
             advertisements.
         ipv6_nd_cache:
           type: dict
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.cache
+            removed: false
+            remove_in_version: 7.0.0
           description: IPv6 neighbor cache options.
           keys:
             dynamic_capacity:
@@ -24905,6 +24925,11 @@ keys:
               description: Force refresh on cache expiry.
         ipv6_nd_prefixes:
           type: list
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.prefixes
+            removed: false
+            remove_in_version: 7.0.0
           primary_key: ipv6_prefix
           items:
             type: dict
@@ -24953,6 +24978,35 @@ keys:
           type: bool
           description: Allow forwarding requests with additional IPv6 addresses in
             the gateway address "giaddr" field.
+        ipv6_nd:
+          type: dict
+          $ref: eos_cli_config_gen#/$defs/ipv6_nd
+          keys:
+            other_config_flag:
+              type: bool
+              description: Set the "other stateful configuration" flag in IPv6 router
+                advertisements.
+            cache:
+              type: dict
+              description: IPv6 neighbor cache options.
+              keys:
+                dynamic_capacity:
+                  type: int
+                  description: Capacity of dynamic cache entries.
+                  convert_types:
+                  - str
+                  min: 0
+                  max: 4294967295
+                expire:
+                  type: int
+                  description: Cache entries expirery in seconds.
+                  convert_types:
+                  - str
+                  min: 1
+                  max: 65535
+                refresh_always:
+                  type: bool
+                  description: Force refresh on cache expiry.
         access_group_in:
           type: str
           description: IPv4 access-list name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -25017,7 +25017,7 @@ keys:
                   max: 4294967295
                 expire:
                   type: int
-                  description: Cache entries expirery in seconds.
+                  description: Cache entries expiry in seconds.
                   convert_types:
                   - str
                   min: 1

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -214,13 +214,33 @@ keys:
             description: IPv6 address or IPv6_address/Mask.
         ipv6_nd_ra_disabled:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.ra.disabled
+            removed: false
+            remove_in_version: 7.0.0
         ipv6_nd_managed_config_flag:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.managed_config_flag
+            removed: false
+            remove_in_version: 7.0.0
         ipv6_nd_other_config_flag:
           type: bool
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.other_config_flag
+            removed: false
+            remove_in_version: 7.0.0
           description: Set the "other stateful configuration" flag in IPv6 router advertisements.
         ipv6_nd_cache:
           type: dict
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.cache
+            removed: false
+            remove_in_version: 7.0.0
           description: IPv6 neighbor cache options.
           keys:
             dynamic_capacity:
@@ -242,6 +262,11 @@ keys:
               description: Force refresh on cache expiry.
         ipv6_nd_prefixes:
           type: list
+          deprecation:
+            warning: true
+            new_key: ipv6_nd.prefixes
+            removed: false
+            remove_in_version: 7.0.0
           primary_key: ipv6_prefix
           items:
             type: dict
@@ -288,6 +313,34 @@ keys:
         ipv6_dhcp_relay_all_subnets:
           type: bool
           description: Allow forwarding requests with additional IPv6 addresses in the gateway address "giaddr" field.
+        ipv6_nd:
+          type: dict
+          $ref: "eos_cli_config_gen#/$defs/ipv6_nd"
+          keys:
+            other_config_flag:
+              type: bool
+              description: Set the "other stateful configuration" flag in IPv6 router advertisements.
+            cache:
+              type: dict
+              description: IPv6 neighbor cache options.
+              keys:
+                dynamic_capacity:
+                  type: int
+                  description: Capacity of dynamic cache entries.
+                  convert_types:
+                    - str
+                  min: 0
+                  max: 4294967295
+                expire:
+                  type: int
+                  description: Cache entries expirery in seconds.
+                  convert_types:
+                    - str
+                  min: 1
+                  max: 65535
+                refresh_always:
+                  type: bool
+                  description: Force refresh on cache expiry.
         access_group_in:
           type: str
           description: IPv4 access-list name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -333,7 +333,7 @@ keys:
                   max: 4294967295
                 expire:
                   type: int
-                  description: Cache entries expirery in seconds.
+                  description: Cache entries expiry in seconds.
                   convert_types:
                     - str
                   min: 1

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
@@ -154,7 +154,7 @@ class VlanInterfacesMixin(Protocol):
 
             if svi.ipv6_nd.advertise_ipv6_address_virtuals:
                 for ipv6_address in svi.ipv6_address_virtuals:
-                    vlan_interface_config.ipv6_nd_prefixes.append_new(
+                    vlan_interface_config.ipv6_nd.prefixes.append_new(
                         ipv6_prefix=ipv6_address,
                         valid_lifetime=svi.ipv6_nd.valid_lifetime,
                         preferred_lifetime=svi.ipv6_nd.preferred_lifetime,


### PR DESCRIPTION
## Change Summary

Add ipv6_nd support to vlan_interfaces

## Related Issue(s)

Fixes Part of https://github.com/aristanetworks/avd/issues/6571

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```
# IPv6 Neighbor Discovery protocol.
        ipv6_nd:

          # Set the "other stateful configuration" flag in IPv6 router advertisements.
          other_config_flag: <bool>

          # IPv6 neighbor cache options.
          cache:

            # Capacity of dynamic cache entries.
            dynamic_capacity: <int; 0-4294967295>

            # Cache entries expirery in seconds.
            expire: <int; 1-65535>

            # Force refresh on cache expiry.
            refresh_always: <bool>

          # Router Advertisement.
          ra:

            # Disable Router Advertisement messages on the interface.
            disabled: <bool>
            rx_accept:

              # Accept default route from received Router Advertisements.
              default_route: <bool>

              # Accept route preference from received Router Advertisements.
              route_preference: <bool>

          # Set the "Managed Address Configuration" (M) flag in Router Advertisements.
          managed_config_flag: <bool>

          # IPv6 prefixes to include in Router Advertisements.
          prefixes:
            - ipv6_prefix: <str; required; unique>

              # Valid lifetime in seconds '<0-4294967295>' or 'infinite'.
              valid_lifetime: <str>

              # Preferred lifetime in seconds '<0-4294967295>' or 'infinite'.
              preferred_lifetime: <str>

              # Indicate that the prefix cannot be used for stateless address autoconfiguration (SLAAC).
              no_autoconfig_flag: <bool>
```

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
