### PR TITLE
Doc: Move the fabric_ip_addressing.loopback.ipv6_prefix_length to Fabric IP Addressing table

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-ip-addressing.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>fabric_ip_addressing</samp>](## "fabric_ip_addressing") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;loopback</samp>](## "fabric_ip_addressing.loopback") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_prefix_length</samp>](## "fabric_ip_addressing.loopback.ipv6_prefix_length") | Integer |  | `128` | Valid Values:<br>- <code>64</code><br>- <code>128</code> | IPv6 prefix length used for Router ID, VTEP and diagnostic loopbacks. |
     | [<samp>&nbsp;&nbsp;mlag</samp>](## "fabric_ip_addressing.mlag") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "fabric_ip_addressing.mlag.algorithm") | String |  | `first_id` | Valid Values:<br>- <code>first_id</code><br>- <code>odd_id</code><br>- <code>same_subnet</code> | This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.<br>Each MLAG link will have a /31¹ subnet with each subnet allocated from the relevant MLAG pool via a calculated offset.<br>The offset is calculated using one of the following algorithms:<br>  - first_id: `(mlag_primary_id - 1) * 2` where `mlag_primary_id` is the ID of the first node defined under the node_group.<br>    This allocation method will skip every other /31¹ subnet making it less space efficient than `odd_id`.<br>  - odd_id: `(odd_id - 1) / 2`. Requires the node_group to have a node with an odd ID and a node with an even ID.<br>  - same_subnet: the offset will always be zero.<br>    This allocation method will use the first /31¹ subnet from the pool for all MLAG links.<br>¹ The prefix length is configurable with a default of /31. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_length</samp>](## "fabric_ip_addressing.mlag.ipv4_prefix_length") | Integer |  | `31` | Min: 1<br>Max: 31 | IPv4 prefix length used for MLAG peer-vlan and L3 point-to-point SVIs over the MLAG peer-link. |
@@ -24,6 +25,9 @@
     ```yaml
     fabric_ip_addressing:
       loopback:
+
+        # IPv6 prefix length used for Router ID, VTEP and diagnostic loopbacks.
+        ipv6_prefix_length: <int; 64 | 128; default=128>
       mlag:
 
         # This variable defines the Multi-chassis Link Aggregation (MLAG) algorithm used.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-loopback-vtep-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-loopback-vtep-configuration.md
@@ -91,9 +91,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;loopback_ipv6_offset</samp>](## "devices.[].loopback_ipv6_offset") | Integer |  | `0` |  | Offset all assigned loopback IPv6 addresses.<br>Required when the 'loopback_ipv6_pool' is same for 2 different node_types (like spine and l3leaf) to avoid overlapping IPs.<br>For example, set the minimum offset l3leaf.defaults.loopback_ipv6_offset: < total # spine switches > or vice versa.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vtep</samp>](## "devices.[].vtep") | Boolean |  |  |  | Node is configured as a VTEP when applicable based on 'overlay_routing_protocol'.<br>Overrides VTEP setting inherited from node_type_keys. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vtep_loopback</samp>](## "devices.[].vtep_loopback") | String |  |  | Pattern: `Loopback[\d/]+` | Set VXLAN source interface. |
-    | [<samp>fabric_ip_addressing</samp>](## "fabric_ip_addressing") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;loopback</samp>](## "fabric_ip_addressing.loopback") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_prefix_length</samp>](## "fabric_ip_addressing.loopback.ipv6_prefix_length") | Integer |  | `128` | Valid Values:<br>- <code>64</code><br>- <code>128</code> | IPv6 prefix length used for Router ID, VTEP and diagnostic loopbacks. |
 
 === "YAML"
 
@@ -421,9 +418,4 @@
 
         # Set VXLAN source interface.
         vtep_loopback: <str>
-    fabric_ip_addressing:
-      loopback:
-
-        # IPv6 prefix length used for Router ID, VTEP and diagnostic loopbacks.
-        ipv6_prefix_length: <int; 64 | 128; default=128>
     ```

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2707,8 +2707,6 @@ keys:
         type: dict
         keys:
           ipv6_prefix_length:
-            documentation_options:
-              table: node-type-loopback-vtep-configuration
             description: IPv6 prefix length used for Router ID, VTEP and diagnostic
               loopbacks.
             type: int

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_ip_addressing.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_ip_addressing.schema.yml
@@ -13,8 +13,6 @@ keys:
         type: dict
         keys:
           ipv6_prefix_length:
-            documentation_options:
-              table: node-type-loopback-vtep-configuration
             description: IPv6 prefix length used for Router ID, VTEP and diagnostic loopbacks.
             type: int
             default: 128


### PR DESCRIPTION
## Change Summary

Move the `fabric_ip_addressing.loopback.ipv6_prefix_length` to Fabric IP Addressing table

## Related Issue(s)

Fixes #6684 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Removed the documentation_options from `fabric_ip_addressing` schema 

## How to test
Check the changes in table

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
