### PR TITLE
Doc(eos_designs): Fix rendering  MD Format `<nn>:<nn>.` is shown as `Format :.` in the description

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
@@ -11,8 +11,8 @@
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "<node_type_keys.key>.defaults") | Dictionary |  |  |  | Define variables for all nodes of this type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -28,8 +28,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -41,8 +41,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.remote_peers.[].bgp_as") | String | Required |  |  | Remote IPVPN Peer's BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -56,8 +56,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -71,8 +71,8 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "device_profiles.[].name") | String | Required, Unique |  |  | Profile Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "device_profiles.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "device_profiles.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "device_profiles.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "device_profiles.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "device_profiles.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -86,8 +86,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "devices.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "devices.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "devices.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "devices.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "devices.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "devices.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "devices.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "devices.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "devices.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "devices.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -111,10 +111,10 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.
@@ -161,10 +161,10 @@
               ipvpn_gateway:
                 enabled: <bool; required>
 
-                # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
                 evpn_domain_id: <str; default="65535:1">
 
-                # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                 ipvpn_domain_id: <str; default="65535:2">
 
                 # Enable D-path for use with BGP bestpath selection algorithm.
@@ -198,10 +198,10 @@
           ipvpn_gateway:
             enabled: <bool; required>
 
-            # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+            # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
-            # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+            # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
             ipvpn_domain_id: <str; default="65535:2">
 
             # Enable D-path for use with BGP bestpath selection algorithm.
@@ -241,10 +241,10 @@
           ipvpn_gateway:
             enabled: <bool; required>
 
-            # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+            # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
-            # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+            # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
             ipvpn_domain_id: <str; default="65535:2">
 
             # Enable D-path for use with BGP bestpath selection algorithm.
@@ -284,10 +284,10 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.
@@ -327,10 +327,10 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -29,7 +29,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -42,7 +42,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -57,7 +57,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -72,7 +72,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "device_profiles.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "device_profiles.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "device_profiles.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "device_profiles.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "device_profiles.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -87,7 +87,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "devices.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "devices.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "devices.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "devices.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "devices.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "devices.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "devices.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_as</samp>](## "devices.[].ipvpn_gateway.local_as") | String |  |  |  | Local BGP AS applied to peering with IPVPN remote peers.<br>BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
@@ -114,7 +114,7 @@
           # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.
@@ -164,7 +164,7 @@
                 # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                 evpn_domain_id: <str; default="65535:1">
 
-                # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                 ipvpn_domain_id: <str; default="65535:2">
 
                 # Enable D-path for use with BGP bestpath selection algorithm.
@@ -201,7 +201,7 @@
             # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
-            # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+            # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
             ipvpn_domain_id: <str; default="65535:2">
 
             # Enable D-path for use with BGP bestpath selection algorithm.
@@ -244,7 +244,7 @@
             # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
-            # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+            # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
             ipvpn_domain_id: <str; default="65535:2">
 
             # Enable D-path for use with BGP bestpath selection algorithm.
@@ -287,7 +287,7 @@
           # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.
@@ -330,7 +330,7 @@
           # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
-          # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
           ipvpn_domain_id: <str; default="65535:2">
 
           # Enable D-path for use with BGP bestpath selection algorithm.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "<node_type_keys.key>.defaults") | Dictionary |  |  |  | Define variables for all nodes of this type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -28,7 +28,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_as</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.remote_peers.[].bgp_as") | String | Required |  |  | Remote IPVPN Peer's BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -56,7 +56,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -71,7 +71,7 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "device_profiles.[].name") | String | Required, Unique |  |  | Profile Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "device_profiles.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "device_profiles.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "device_profiles.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "device_profiles.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "device_profiles.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -86,7 +86,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "devices.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_gateway</samp>](## "devices.[].ipvpn_gateway") | Dictionary |  |  |  | Node is acting as IP-VPN Gateway for EVPN to MPLS-IP-VPN Interworking. The BGP peer group used for this is "bgp_peer_groups.ipvpn_gateway_peers".<br>L3 Reachability is required for this to work, the preferred method to establish underlay connectivity is to use core_interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "devices.[].ipvpn_gateway.enabled") | Boolean | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "devices.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "devices.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipvpn_domain_id</samp>](## "devices.[].ipvpn_gateway.ipvpn_domain_id") | String |  | `65535:2` |  | Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable_d_path</samp>](## "devices.[].ipvpn_gateway.enable_d_path") | Boolean |  | `True` |  | Enable D-path for use with BGP bestpath selection algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "devices.[].ipvpn_gateway.maximum_routes") | Integer |  | `0` |  | Maximum routes to accept from IPVPN remote peers. |
@@ -111,7 +111,7 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
           # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
@@ -161,7 +161,7 @@
               ipvpn_gateway:
                 enabled: <bool; required>
 
-                # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                 evpn_domain_id: <str; default="65535:1">
 
                 # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
@@ -198,7 +198,7 @@
           ipvpn_gateway:
             enabled: <bool; required>
 
-            # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+            # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
             # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
@@ -241,7 +241,7 @@
           ipvpn_gateway:
             enabled: <bool; required>
 
-            # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+            # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
             evpn_domain_id: <str; default="65535:1">
 
             # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
@@ -284,7 +284,7 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
           # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
@@ -327,7 +327,7 @@
         ipvpn_gateway:
           enabled: <bool; required>
 
-          # Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+          # Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
           evpn_domain_id: <str; default="65535:1">
 
           # Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -7625,13 +7625,13 @@ class EosDesigns(EosDesignsRootModel):
             enabled: bool
             evpn_domain_id: str
             """
-            Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
             Default value: `"65535:1"`
             """
             ipvpn_domain_id: str
             """
-            Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
             Default value: `"65535:2"`
             """
@@ -7688,8 +7688,8 @@ class EosDesigns(EosDesignsRootModel):
 
                     Args:
                         enabled: enabled
-                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                         local_as:
@@ -12729,13 +12729,13 @@ class EosDesigns(EosDesignsRootModel):
             enabled: bool
             evpn_domain_id: str
             """
-            Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
             Default value: `"65535:1"`
             """
             ipvpn_domain_id: str
             """
-            Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
             Default value: `"65535:2"`
             """
@@ -12792,8 +12792,8 @@ class EosDesigns(EosDesignsRootModel):
 
                     Args:
                         enabled: enabled
-                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                         local_as:
@@ -36419,13 +36419,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -36482,8 +36482,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -41500,13 +41500,13 @@ class EosDesigns(EosDesignsRootModel):
                             enabled: bool
                             evpn_domain_id: str
                             """
-                            Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                             Default value: `"65535:1"`
                             """
                             ipvpn_domain_id: str
                             """
-                            Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                             Default value: `"65535:2"`
                             """
@@ -41563,8 +41563,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                     Args:
                                         enabled: enabled
-                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                         local_as:
@@ -46544,13 +46544,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -46607,8 +46607,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -51651,13 +51651,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -51714,8 +51714,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -69260,13 +69260,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -69323,8 +69323,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -74341,13 +74341,13 @@ class EosDesigns(EosDesignsRootModel):
                             enabled: bool
                             evpn_domain_id: str
                             """
-                            Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                             Default value: `"65535:1"`
                             """
                             ipvpn_domain_id: str
                             """
-                            Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                             Default value: `"65535:2"`
                             """
@@ -74404,8 +74404,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                     Args:
                                         enabled: enabled
-                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                         local_as:
@@ -79385,13 +79385,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -79448,8 +79448,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -84492,13 +84492,13 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -84555,8 +84555,8 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -7631,7 +7631,7 @@ class EosDesigns(EosDesignsRootModel):
             """
             ipvpn_domain_id: str
             """
-            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+            Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
             Default value: `"65535:2"`
             """
@@ -7689,7 +7689,7 @@ class EosDesigns(EosDesignsRootModel):
                     Args:
                         enabled: enabled
                         evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                         local_as:
@@ -12735,7 +12735,7 @@ class EosDesigns(EosDesignsRootModel):
             """
             ipvpn_domain_id: str
             """
-            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+            Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
             Default value: `"65535:2"`
             """
@@ -12793,7 +12793,7 @@ class EosDesigns(EosDesignsRootModel):
                     Args:
                         enabled: enabled
                         evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                         local_as:
@@ -36425,7 +36425,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -36483,7 +36483,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -41506,7 +41506,7 @@ class EosDesigns(EosDesignsRootModel):
                             """
                             ipvpn_domain_id: str
                             """
-                            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                            Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                             Default value: `"65535:2"`
                             """
@@ -41564,7 +41564,7 @@ class EosDesigns(EosDesignsRootModel):
                                     Args:
                                         enabled: enabled
                                         evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                         local_as:
@@ -46550,7 +46550,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -46608,7 +46608,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -51657,7 +51657,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -51715,7 +51715,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -69266,7 +69266,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -69324,7 +69324,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -74347,7 +74347,7 @@ class EosDesigns(EosDesignsRootModel):
                             """
                             ipvpn_domain_id: str
                             """
-                            Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                            Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                             Default value: `"65535:2"`
                             """
@@ -74405,7 +74405,7 @@ class EosDesigns(EosDesignsRootModel):
                                     Args:
                                         enabled: enabled
                                         evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                        ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                         local_as:
@@ -79391,7 +79391,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -79449,7 +79449,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:
@@ -84498,7 +84498,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         ipvpn_domain_id: str
                         """
-                        Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:2"`
                         """
@@ -84556,7 +84556,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Args:
                                     enabled: enabled
                                     evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
-                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                                    ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
                                     local_as:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -7625,7 +7625,7 @@ class EosDesigns(EosDesignsRootModel):
             enabled: bool
             evpn_domain_id: str
             """
-            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+            Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
             Default value: `"65535:1"`
             """
@@ -7688,7 +7688,7 @@ class EosDesigns(EosDesignsRootModel):
 
                     Args:
                         enabled: enabled
-                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                         ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -12729,7 +12729,7 @@ class EosDesigns(EosDesignsRootModel):
             enabled: bool
             evpn_domain_id: str
             """
-            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+            Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
             Default value: `"65535:1"`
             """
@@ -12792,7 +12792,7 @@ class EosDesigns(EosDesignsRootModel):
 
                     Args:
                         enabled: enabled
-                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                         ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -36419,7 +36419,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -36482,7 +36482,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -41500,7 +41500,7 @@ class EosDesigns(EosDesignsRootModel):
                             enabled: bool
                             evpn_domain_id: str
                             """
-                            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                            Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                             Default value: `"65535:1"`
                             """
@@ -41563,7 +41563,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                     Args:
                                         enabled: enabled
-                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                         ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -46544,7 +46544,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -46607,7 +46607,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -51651,7 +51651,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -51714,7 +51714,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -69260,7 +69260,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -69323,7 +69323,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -74341,7 +74341,7 @@ class EosDesigns(EosDesignsRootModel):
                             enabled: bool
                             evpn_domain_id: str
                             """
-                            Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                            Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                             Default value: `"65535:1"`
                             """
@@ -74404,7 +74404,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                     Args:
                                         enabled: enabled
-                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                        evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                         ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                         enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                         maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -79385,7 +79385,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -79448,7 +79448,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.
@@ -84492,7 +84492,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool
                         evpn_domain_id: str
                         """
-                        Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                        Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
 
                         Default value: `"65535:1"`
                         """
@@ -84555,7 +84555,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                 Args:
                                     enabled: enabled
-                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                                    evpn_domain_id: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                                     ipvpn_domain_id: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                                     enable_d_path: Enable D-path for use with BGP bestpath selection algorithm.
                                     maximum_routes: Maximum routes to accept from IPVPN remote peers.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -11087,7 +11087,7 @@ $defs:
                 required: true
               evpn_domain_id:
                 description: Domain ID to assign to EVPN address family for use with
-                  D-path. `Format <nn>:<nn>`.
+                  D-path. Format `<nn>:<nn>`.
                 type: str
                 default: '65535:1'
               ipvpn_domain_id:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -11087,12 +11087,12 @@ $defs:
                 required: true
               evpn_domain_id:
                 description: Domain ID to assign to EVPN address family for use with
-                  D-path. Format <nn>:<nn>.
+                  D-path. `Format <nn>:<nn>`.
                 type: str
                 default: '65535:1'
               ipvpn_domain_id:
                 description: Domain ID to assign to IPVPN address families for use
-                  with D-path. Format <nn>:<nn>.
+                  with D-path. `Format <nn>:<nn>`.
                 type: str
                 default: '65535:2'
               enable_d_path:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -11092,7 +11092,7 @@ $defs:
                 default: '65535:1'
               ipvpn_domain_id:
                 description: Domain ID to assign to IPVPN address families for use
-                  with D-path. `Format <nn>:<nn>`.
+                  with D-path. Format `<nn>:<nn>`.
                 type: str
                 default: '65535:2'
               enable_d_path:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -833,7 +833,7 @@ $defs:
                 type: str
                 default: "65535:1"
               ipvpn_domain_id:
-                description: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
+                description: Domain ID to assign to IPVPN address families for use with D-path. Format `<nn>:<nn>`.
                 type: str
                 default: "65535:2"
               enable_d_path:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -829,11 +829,11 @@ $defs:
                 type: bool
                 required: true
               evpn_domain_id:
-                description: Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>.
+                description: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
                 type: str
                 default: "65535:1"
               ipvpn_domain_id:
-                description: Domain ID to assign to IPVPN address families for use with D-path. Format <nn>:<nn>.
+                description: Domain ID to assign to IPVPN address families for use with D-path. `Format <nn>:<nn>`.
                 type: str
                 default: "65535:2"
               enable_d_path:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -829,7 +829,7 @@ $defs:
                 type: bool
                 required: true
               evpn_domain_id:
-                description: Domain ID to assign to EVPN address family for use with D-path. `Format <nn>:<nn>`.
+                description: Domain ID to assign to EVPN address family for use with D-path. Format `<nn>:<nn>`.
                 type: str
                 default: "65535:1"
               ipvpn_domain_id:


### PR DESCRIPTION
## Change Summary

Noticed during review the following description which is not shown properly once MD gets rendered: Format <nn>:<nn>. is shown as Format :. in the description of the input var in table format (https://ansible-avd--5867.org.readthedocs.build/en/5867/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.html#node-type-evpn-gateway-configuration as an example):

```
./roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md:14:    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.defaults.ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
./roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md:31:    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
./roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md:44:    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
./roles/eos_designs/docs/tables/node-type-evpn-ipvpn-gateway-configuration.md:59:    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_domain_id</samp>](## "<node_type_keys.key>.nodes.[].ipvpn_gateway.evpn_domain_id") | String |  | `65535:1` |  | Domain ID to assign to EVPN address family for use with D-path. Format <nn>:<nn>. |
```

Originally posted by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5867#issuecomment-3336075937

## Related Issue(s)

Fixes #5928 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
updated description

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
