### PR TITLE
Feat(eos_designs): Add new igmp_snooping model under network_services

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -4,9 +4,13 @@ no aaa root
 !
 vlan internal order ascending range 1006 1199
 !
-ip igmp snooping vlan 252 querier
-ip igmp snooping vlan 252 querier address 192.168.255.101
-ip igmp snooping vlan 252 fast-leave
+ip igmp snooping vlan 301 querier
+ip igmp snooping vlan 301 querier address 192.168.255.101
+ip igmp snooping vlan 301 querier version 3
+ip igmp snooping vlan 302 querier
+ip igmp snooping vlan 302 querier address 2.2.2.2
+ip igmp snooping vlan 302 querier version 2
+no ip igmp snooping vlan 401
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -14,11 +18,20 @@ service routing protocols model multi-agent
 !
 hostname host1
 !
-vlan 251
-   name MULTICAST_DISABLED_251
+vlan 22
+   name VLAN_22
 !
-vlan 252
-   name MULTICAST_ENABLED_252
+vlan 301
+   name VLAN_301
+!
+vlan 302
+   name VLAN_302
+!
+vlan 401
+   name VLAN_401
+!
+vrf instance IGMP_QUERIER_TEST_3
+   description IGMP_QUERIER_TEST
 !
 radius-server host 11.10.10.11 key 7 071B245F5A
 radius-server host 11.10.10.5 vrf MGMT1 tls ssl-profile HOST_SSL_PROFILE port 2080
@@ -81,15 +94,26 @@ interface Management1
    no shutdown
    ip address 192.168.0.103/24
 !
+interface Vlan22
+   description VLAN_22
+   no shutdown
+   vrf IGMP_QUERIER_TEST_3
+   ip address virtual 10.0.22.1/24
+!
 interface Vxlan1
    description host1_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
-   vxlan vlan 251 vni 10251
-   vxlan vlan 252 vni 10252
-   vxlan vlan 252 multicast group 232.0.0.251
+   vxlan vlan 22 vni 40022
+   vxlan vlan 301 vni 30301
+   vxlan vlan 302 vni 30302
+   vxlan vlan 401 vni 40401
+   vxlan vrf IGMP_QUERIER_TEST_3 vni 41
+!
+ip virtual-router mac-address 00:1c:73:00:00:01
 !
 ip routing
+ip routing vrf IGMP_QUERIER_TEST_3
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -125,15 +149,24 @@ router bgp 101
    neighbor 192.168.42.201 description host1_Ethernet42
    redistribute connected route-map RM-CONN-2-BGP
    !
-   vlan 251
-      rd 192.168.255.101:10251
-      route-target both 10251:10251
+   vlan 22
+      rd 192.168.255.101:40022
+      route-target both 40022:40022
       redistribute learned
    !
-   vlan 252
-      rd 192.168.255.101:10252
-      route-target both 10252:10252
-      redistribute igmp
+   vlan 301
+      rd 192.168.255.101:30301
+      route-target both 30301:30301
+      redistribute learned
+   !
+   vlan 302
+      rd 192.168.255.101:30302
+      route-target both 30302:30302
+      redistribute learned
+   !
+   vlan 401
+      rd 192.168.255.101:40401
+      route-target both 40401:40401
       redistribute learned
    !
    address-family evpn
@@ -147,6 +180,13 @@ router bgp 101
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf IGMP_QUERIER_TEST_3
+      rd 192.168.255.101:41
+      route-target import evpn 41:41
+      route-target export evpn 41:41
+      router-id 192.168.255.101
+      redistribute connected
 !
 router multicast
    ipv4

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -68,11 +68,18 @@ hostname: host1
 ip_igmp_snooping:
   globally_enabled: true
   vlans:
-  - id: 252
+  - id: 301
     querier:
       enabled: true
       address: 192.168.255.101
-    fast_leave: true
+      version: 3
+  - id: 302
+    querier:
+      enabled: true
+      address: 2.2.2.2
+      version: 2
+  - id: 401
+    enabled: false
 ip_radius:
   source_interface: Vlan123
   vrfs:
@@ -88,6 +95,7 @@ ip_tacacs:
     source_interface: Vlan125
   - name: MGMT1
     source_interface: Vlan125
+ip_virtual_router_mac_address: 00:1c:73:00:00:01
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID
@@ -180,27 +188,46 @@ router_bgp:
       enabled: true
       route_map: RM-CONN-2-BGP
   vlans:
-  - id: 251
+  - id: 301
     metadata:
       tenants:
-      - Tenant_F
-    rd: 192.168.255.101:10251
+      - Tenant_G
+    rd: 192.168.255.101:30301
     route_targets:
       both:
-      - 10251:10251
+      - 30301:30301
     redistribute_routes:
     - learned
-  - id: 252
+  - id: 302
     metadata:
       tenants:
-      - Tenant_F
-    rd: 192.168.255.101:10252
+      - Tenant_G
+    rd: 192.168.255.101:30302
     route_targets:
       both:
-      - 10252:10252
+      - 30302:30302
     redistribute_routes:
     - learned
-    - igmp
+  - id: 22
+    metadata:
+      tenants:
+      - Tenant_H
+    rd: 192.168.255.101:40022
+    route_targets:
+      both:
+      - 40022:40022
+    redistribute_routes:
+    - learned
+  - id: 401
+    metadata:
+      tenants:
+      - Tenant_H
+    rd: 192.168.255.101:40401
+    route_targets:
+      both:
+      - 40401:40401
+    redistribute_routes:
+    - learned
   address_family_evpn:
     domain_identifier: '65200:2'
     domain_identifier_remote: '65100:1'
@@ -216,6 +243,22 @@ router_bgp:
     peer_groups:
     - name: IPv4-UNDERLAY-PEERS
       activate: true
+  vrfs:
+  - name: IGMP_QUERIER_TEST_3
+    rd: 192.168.255.101:41
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '41:41'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '41:41'
+    router_id: 192.168.255.101
+    redistribute:
+      connected:
+        enabled: true
 router_multicast:
   ipv4:
     routing: true
@@ -253,25 +296,52 @@ tacacs_servers:
     key: 071B245F5A
   policy_unknown_mandatory_attribute_ignore: false
 transceiver_qsfp_default_mode_4x10: true
+vlan_interfaces:
+- name: Vlan22
+  description: VLAN_22
+  shutdown: false
+  vrf: IGMP_QUERIER_TEST_3
+  ip_address_virtual: 10.0.22.1/24
+  metadata:
+    tenants:
+    - Tenant_H
+    tags:
+    - test_l3
 vlan_internal_order:
   allocation: ascending
   range:
     beginning: 1006
     ending: 1199
 vlans:
-- id: 251
-  name: MULTICAST_DISABLED_251
+- id: 301
+  name: VLAN_301
   metadata:
     tenants:
-    - Tenant_F
-- id: 252
-  name: MULTICAST_ENABLED_252
+    - Tenant_G
+- id: 302
+  name: VLAN_302
   metadata:
     tenants:
-    - Tenant_F
+    - Tenant_G
+- id: 22
+  name: VLAN_22
+  metadata:
+    tenants:
+    - Tenant_H
+- id: 401
+  name: VLAN_401
+  metadata:
+    tenants:
+    - Tenant_H
 vrfs:
 - name: default
   ip_routing: false
+- name: IGMP_QUERIER_TEST_3
+  description: IGMP_QUERIER_TEST
+  ip_routing: true
+  metadata:
+    tenants:
+    - Tenant_H
 vxlan_interface:
   vxlan1:
     description: host1_VTEP
@@ -279,8 +349,14 @@ vxlan_interface:
       source_interface: Loopback1
       udp_port: 4789
       vlans:
-      - id: 251
-        vni: 10251
-      - id: 252
-        vni: 10252
-        multicast_group: 232.0.0.251
+      - id: 301
+        vni: 30301
+      - id: 302
+        vni: 30302
+      - id: 22
+        vni: 40022
+      - id: 401
+        vni: 40401
+      vrfs:
+      - name: IGMP_QUERIER_TEST_3
+        vni: 41

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/igmp_snooping.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/igmp_snooping.yml
@@ -1,0 +1,49 @@
+type: l3leaf
+
+mgmt_gateway: 192.168.200.1
+
+underlay_multicast_pim_sm: true
+evpn_multicast: true
+
+tenants:
+   # Test deprecated tenant-level igmp_snooping_querier key.
+  - name: Tenant_G
+    mac_vrf_vni_base: 30000
+    igmp_snooping_querier:
+      enabled: true
+      source_address: 1.1.1.1
+      version: 3
+    l2vlans:
+      # Expected: querier enabled, address 1.1.1.1, version 3 (inherited from deprecated tenant igmp_snooping_querier)
+      - id: 301
+        name: "VLAN_301"
+        tags: ["test_l2"]
+      # Expected: querier enabled, address 2.2.2.2, version 2 (deprecated L2VLAN igmp_snooping_querier overrides tenant)
+      - id: 302
+        name: "VLAN_302"
+        tags: ["test_l2"]
+        igmp_snooping_querier:
+          source_address: 2.2.2.2
+          version: 2
+
+  # Test deprecated L2VLAN-level igmp_snooping_enabled key.
+  - name: Tenant_H
+    mac_vrf_vni_base: 40000
+    l2vlans:
+      # Expected: igmp snooping disabled (from deprecated igmp_snooping_enabled: false)
+      - id: 401
+        name: "VLAN_401"
+        tags: ["test_l2"]
+        igmp_snooping_enabled: false
+    vrfs:
+      - name: IGMP_QUERIER_TEST_3
+        description: "IGMP_QUERIER_TEST"
+        vrf_vni: 41
+        svis:
+          - id: 22
+            name: "VLAN_22"
+            tags: ['test_l3']
+            enabled: true
+            ip_address_virtual: 10.0.22.1/24
+            igmp_snooping_querier:
+              source_address: main_router_id

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
@@ -13,6 +13,7 @@ l3leaf:
     uplink_interfaces: [Ethernet42]
     uplink_ipv4_pool: 192.168.42.0/24
     platform: vEOS
+    virtual_router_mac_address: 00:1c:73:00:00:01
   nodes:
     - name: host1
       id: 101

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/hosts.yml
@@ -4,7 +4,6 @@ all:
     EOS_DESIGNS_DEPRECATED_VARS:
       hosts:
         host1:
-        host2:
         host_ansible_only:
     IGNORE_IN_PYTEST:
       hosts:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_deprecated_vars/inventory/hosts.yml
@@ -4,6 +4,7 @@ all:
     EOS_DESIGNS_DEPRECATED_VARS:
       hosts:
         host1:
+        host2:
         host_ansible_only:
     IGNORE_IN_PYTEST:
       hosts:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-vrfs-tenant-igmp-snooping-conflict.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-vrfs-tenant-igmp-snooping-conflict.yml
@@ -21,8 +21,9 @@ l3leaf:
 
 tenants:
   - name: TENANT1
-    igmp_snooping_querier:
-      enabled: true
+    igmp_snooping:
+      querier:
+        enabled: true
     mac_vrf_vni_base: 10000
     vrfs:
       - name: VRF1
@@ -35,8 +36,9 @@ tenants:
 
   - name: DUPLICATE_TENANT1
     # Conflicting IGMP snooping setting on tenant so an error will be raised.
-    igmp_snooping_querier:
-      enabled: false
+    igmp_snooping:
+      querier:
+        enabled: false
     mac_vrf_vni_base: 10000
     vrfs:
       - name: VRF1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/evpn-multicast-missing-underlay-multicast.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/evpn-multicast-missing-underlay-multicast.yml
@@ -16,6 +16,6 @@ l3leaf:
 type: l3leaf
 
 expected_error_message: >-
-  'evpn_multicast: True' is only supported in combination with and 'igmp_snooping.enabled : true'
+  'evpn_multicast: True' is only supported in combination with and 'igmp_snooping_enabled : true'
   and either node_settings 'underlay_multicast.pim_sm.enabled: true' or 'underlay_multicast_pim_sm: true'
   for host 'evpn-multicast-missing-underlay-multicast'.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/evpn-multicast-missing-underlay-multicast.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/evpn-multicast-missing-underlay-multicast.yml
@@ -16,6 +16,6 @@ l3leaf:
 type: l3leaf
 
 expected_error_message: >-
-  'evpn_multicast: True' is only supported in combination with and 'igmp_snooping_enabled : true'
+  'evpn_multicast: True' is only supported in combination with and 'igmp_snooping.enabled : true'
   and either node_settings 'underlay_multicast.pim_sm.enabled: true' or 'underlay_multicast_pim_sm: true'
   for host 'evpn-multicast-missing-underlay-multicast'.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2leaf-l2vlan-igmp-querier-no-router-id.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2leaf-l2vlan-igmp-querier-no-router-id.yml
@@ -24,12 +24,13 @@ l2leaf:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: main_router_id
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: main_router_id
     l2vlans:
       - id: 110
         name: test_l2vlan
 expected_error_message: >-
   Invalid IGMP snooping querier source address for VLAN 'test_l2vlan' in Tenant 'Tenant_A'.
-  The value 'None' resolved from 'igmp_snooping_querier.source_address: main_router_id' is not a valid IPv4 address.
+  The value 'None' resolved from 'igmp_snooping.querier.source_address: main_router_id' is not a valid IPv4 address.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2leaf-svi-igmp-querier-no-router-id.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2leaf-svi-igmp-querier-no-router-id.yml
@@ -28,9 +28,10 @@ l2leaf:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: main_router_id
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: main_router_id
     vrfs:
       - name: VRF1
         vrf_vni: 11
@@ -40,4 +41,4 @@ tenants:
             enabled: true
 expected_error_message: >-
   Invalid IGMP snooping querier source address for VLAN 'test_svi' in VRF 'VRF1' in Tenant 'Tenant_A'.
-  The value 'None' resolved from 'igmp_snooping_querier.source_address: main_router_id' is not a valid IPv4 address.
+  The value 'None' resolved from 'igmp_snooping.querier.source_address: main_router_id' is not a valid IPv4 address.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2vlan-igmp-snooping-querier-source-address-resolve.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-l2vlan-igmp-snooping-querier-source-address-resolve.yml
@@ -14,13 +14,14 @@ l3leaf:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: none
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: none
     l2vlans:
       - id: 110
         name: research1
 
 expected_error_message: >-
   Invalid IGMP snooping querier source address for VLAN 'research1' in Tenant 'Tenant_A'.
-  The value 'none' resolved from 'igmp_snooping_querier.source_address: none' is not a valid IPv4 address.
+  The value 'none' resolved from 'igmp_snooping.querier.source_address: none' is not a valid IPv4 address.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-svi-igmp-snooping-querier-source-address-for-diagnostic-loopback.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-svi-igmp-snooping-querier-source-address-for-diagnostic-loopback.yml
@@ -14,9 +14,10 @@ l3leaf:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: diagnostic_loopback
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: diagnostic_loopback
     vrfs:
       - name: IGMP_QUERIER_TEST_3
         description: "IGMP_QUERIER_TEST_3"
@@ -29,4 +30,4 @@ tenants:
 expected_error_message: >-
   Invalid configuration on VRF 'IGMP_QUERIER_TEST_3' in Tenant 'Tenant_A'.
   'vtep_diagnostic.loopback' along with either 'vtep_diagnostic.loopback_ip_pools' or
-  'vtep_diagnostic.loopback_ip_range' must be defined when 'igmp_snooping_querier.source_address' is set to 'diagnostic_loopback' on the VRF.
+  'vtep_diagnostic.loopback_ip_range' must be defined when 'igmp_snooping.querier.source_address' is set to 'diagnostic_loopback' on the VRF.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-svi-igmp-snooping-querier-source-address-resolve.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-svi-igmp-snooping-querier-source-address-resolve.yml
@@ -14,9 +14,10 @@ l3leaf:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: none
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: none
     vrfs:
       - name: IGMP_QUERIER_TEST_3
         description: "IGMP_QUERIER_TEST_3"
@@ -28,4 +29,4 @@ tenants:
 
 expected_error_message: >-
   Invalid IGMP snooping querier source address for VLAN 'VLAN_21' in VRF 'IGMP_QUERIER_TEST_3' in Tenant 'Tenant_A'.
-  The value 'none' resolved from 'igmp_snooping_querier.source_address: none' is not a valid IPv4 address.
+  The value 'none' resolved from 'igmp_snooping.querier.source_address: none' is not a valid IPv4 address.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
@@ -53,7 +53,8 @@ svi_profiles:
   - profile: WITH_DHCP_AND_SNOOPING
     enabled: true
     ip_address_virtual: 10.1.11.254/24
-    igmp_snooping_enabled: false
+    igmp_snooping:
+      enabled: false
     ip_helpers:
       - ip_helper: 1.1.1.1
         source_interface: lo100

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
@@ -27,7 +27,7 @@ bgp_peer_groups:
 tenants:
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp:
+    igmp_snooping:
       fast_leave: true
     evpn_l2_multicast:
       enabled: true
@@ -80,7 +80,7 @@ tenants:
             tags: ["test_l3"]
             enabled: true
             ip_address_virtual: 10.2.11.1/24
-            igmp_snooping_querier:
+            igmp_snooping:
               fast_leave: false
             evpn_l2_multicast:
               enabled: false
@@ -115,7 +115,7 @@ tenants:
       - id: 256
         name: "MULTICAST_DISABLED_256"
         tags: ["test_l2"]
-        # test for fast-leave when tenant level evpn_l2_multicast.enabled: true, igmp.fast_leave: true and l2vlans.evpn_l2_multicast.enabled: false
+        # test for fast-leave when tenant level evpn_l2_multicast.enabled: true, igmp_snooping.fast_leave: true and l2vlans.evpn_l2_multicast.enabled: false
         # fast_leave will be applied to VLAN 256 regardless of l2vlans.evpn_l2_multicast.enabled.
         evpn_l2_multicast:
           enabled: false
@@ -148,9 +148,10 @@ tenants:
       enabled: true
       underlay_l2_multicast_group_ipv4_pool: 232.1.0.0-232.1.0.40
       underlay_l2_multicast_group_ipv4_pool_offset: 1
-    igmp_snooping_querier:
-      version: 3
-      source_address: 1.1.1.1
+    igmp_snooping:
+      querier:
+        version: 3
+        source_address: 1.1.1.1
     vrfs:
       - name: MULTICAST_ENABLED_1_2
         description: "MULTICAST_ENABLED_1_2"
@@ -171,13 +172,13 @@ tenants:
             enabled: true
             ip_address_virtual: 10.0.1.1/24
             # test for fast-leave when tenant level evpn_l2_multicast.enabled: false and
-            # vrfs.svis.evpn_l2_multicast.enabled: true with igmp_snooping_querier.fast_leave: true
+            # vrfs.svis.evpn_l2_multicast.enabled: true with igmp_snooping.fast_leave: true
             evpn_l2_multicast:
               enabled: true
             # To test vxlan_flood_multicast disabled at l2vlans but enabled at tenant
             vxlan_flood_multicast:
               enabled: false
-            igmp_snooping_querier:
+            igmp_snooping:
               fast_leave: true
           - id: 2
             name: "MULTICAST_ENABLED_2"
@@ -209,9 +210,10 @@ tenants:
             ip_address_virtual: 10.0.3.1/24
             evpn_l2_multicast:
               enabled: true
-            igmp_snooping_querier:
-              version: 1
-              source_address: 2.2.2.2
+            igmp_snooping:
+              querier:
+                version: 1
+                source_address: 2.2.2.2
           - id: 4
             name: "MULTICAST_DISABLED_4"
             tags: ["test_l3"]
@@ -261,9 +263,10 @@ tenants:
         tags: ["test_l2"]
         evpn_l2_multicast:
           enabled: true
-        igmp_snooping_querier:
-          version: 1
-          source_address: 2.2.2.2
+        igmp_snooping:
+          querier:
+            version: 1
+            source_address: 2.2.2.2
       - id: 10
         name: "MULTICAST_VXLAN_FLOOD_ENABLED_WITH_UNDERLAY_MULTICAST_GROUP"
         tags: ["test_l2"]
@@ -363,9 +366,10 @@ tenants:
             tags: ["test_l3"]
             enabled: true
             ip_address_virtual: 10.2.23.1/24
-            # test for fast-leave when igmp_snooping_querier.fast_leave: true
-            igmp_snooping_querier:
-              enabled: true
+            # test for fast-leave when igmp_snooping.fast_leave: true
+            igmp_snooping:
+              querier:
+                enabled: true
               fast_leave: true
           - id: 231
             name: "L3_MULTICAST_DISABLED_231"

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
@@ -6,23 +6,26 @@ mgmt_gateway: 192.168.200.5
 
 svi_profiles:
   - profile: IGMP_QUERIER_PARENT
-    igmp_snooping_querier:
-      enabled: true
+    igmp_snooping:
+      querier:
+        enabled: true
   - profile: IGMP_QUERIER_CHILD_1
     parent_profile: "IGMP_QUERIER_PARENT"
   - profile: IGMP_QUERIER_CHILD_2
     parent_profile: "IGMP_QUERIER_PARENT"
-    igmp_snooping_querier:
-      enabled: true
-      source_address: 1.1.1.1
-      version: 3
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: 1.1.1.1
+        version: 3
 
 tenants:
-# igmp_snooping_querier enable on Tenant
+# igmp_snooping.querier enable on Tenant
   - name: Tenant_A
     mac_vrf_vni_base: 10000
-    igmp_snooping_querier:
-      enabled: true
+    igmp_snooping:
+      querier:
+        enabled: true
     vrfs:
       - name: IGMP_QUERIER_TEST_1
         description: "IGMP_QUERIER_TEST_1"
@@ -47,9 +50,10 @@ tenants:
             tags: ['test_l3']
             enabled: true
             ip_address_virtual: 10.0.2.1/24
-            igmp_snooping_querier:
-              version: 3
-              source_address: vrf_router_id
+            igmp_snooping:
+              querier:
+                version: 3
+                source_address: vrf_router_id
         # Expected results:
         # igmp querier disabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
           - id: 3
@@ -57,8 +61,9 @@ tenants:
             tags: ['test_l3']
             enabled: true
             ip_address_virtual: 10.0.3.1/24
-            igmp_snooping_querier:
-              enabled: false
+            igmp_snooping:
+              querier:
+                enabled: false
     l2vlans:
       # Expected results:
       # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1,
@@ -70,24 +75,27 @@ tenants:
       - id: 102
         name: "VLAN_102"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          version: 3
-          source_address: 2.2.2.2
+        igmp_snooping:
+          querier:
+            version: 3
+            source_address: 2.2.2.2
       # Expected results:
       # igmp querier disable querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
       - id: 103
         name: "VLAN_103"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          enabled: false
+        igmp_snooping:
+          querier:
+            enabled: false
 
 # Test setting source address and version at tenant level
   - name: Tenant_B
     mac_vrf_vni_base: 20000
-    igmp_snooping_querier:
-      enabled: true
-      source_address: 1.1.1.1
-      version: 3
+    igmp_snooping:
+      querier:
+        enabled: true
+        source_address: 1.1.1.1
+        version: 3
     vrfs:
       - name: IGMP_QUERIER_TEST_2
         description: "IGMP_QUERIER_TEST_2"
@@ -110,9 +118,10 @@ tenants:
             tags: ['test_l3']
             enabled: true
             ip_address_virtual: 10.0.12.1/24
-            igmp_snooping_querier:
-              version: 2
-              source_address: diagnostic_loopback
+            igmp_snooping:
+              querier:
+                version: 2
+                source_address: diagnostic_loopback
     l2vlans:
       # Expected results:
       # igmp querier enable, querier address set to 1.1.1.1, and version set to 3
@@ -124,17 +133,19 @@ tenants:
       - id: 112
         name: "VLAN_112"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          version: 2
+        igmp_snooping:
+          querier:
+            version: 2
       - id: 113
         name: "VLAN_113"
         tags: ['test_l2']
       # Expected results:
       # igmp querier disabled, querier address set to 1.1.1.1, and version set to 3
-        igmp_snooping_querier:
-          enabled: false
+        igmp_snooping:
+          querier:
+            enabled: false
 
-# Tests with setting igmp_snooping_querier at SVI level with profiles
+# Tests with setting igmp_snooping.querier at SVI level with profiles
   - name: Tenant_D
     mac_vrf_vni_base: 40000
     vrfs:
@@ -158,8 +169,9 @@ tenants:
             enabled: true
             ip_address_virtual: 10.0.22.1/24
             profile: IGMP_QUERIER_CHILD_2
-            igmp_snooping_querier:
-              source_address: main_router_id
+            igmp_snooping:
+              querier:
+                source_address: main_router_id
           # Expected results:
           # igmp querier enable, querier address set to 2.2.2.2, and version set to 1
           - id: 23
@@ -167,10 +179,11 @@ tenants:
             tags: ['test_l3']
             enabled: true
             ip_address_virtual: 10.0.23.1/24
-            igmp_snooping_querier:
-              enabled: true
-              source_address: 2.2.2.2
-              version: 1
+            igmp_snooping:
+              querier:
+                enabled: true
+                source_address: 2.2.2.2
+                version: 1
             profile: IGMP_QUERIER_CHILD_2
 
     l2vlans:
@@ -179,22 +192,25 @@ tenants:
       - id: 121
         name: "VLAN_121"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          enabled: true
-          source_address: 2.2.2.2
-          version: 1
+        igmp_snooping:
+          querier:
+            enabled: true
+            source_address: 2.2.2.2
+            version: 1
       # Expected results:
       # igmp querier enable, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
       - id: 122
         name: "VLAN_122"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          enabled: true
-          source_address: vrf_router_id
+        igmp_snooping:
+          querier:
+            enabled: true
+            source_address: vrf_router_id
       # Expected results:
       # igmp querier disabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
       - id: 123
         name: "VLAN_123"
         tags: ['test_l2']
-        igmp_snooping_querier:
-          enabled: false
+        igmp_snooping:
+          querier:
+            enabled: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -80,21 +80,25 @@ svi_profiles:
 #### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
 # Tests logic for network services: ip igmp snooping
 # Precedence order:
-# 1. svi.igmp_snooping_enabled
-# 2. svi_profile.igmp_snooping_enabled
-# 3. svi_parent_profile.igmp_snooping_enabled
+# 1. svi.igmp_snooping.enabled
+# 2. svi_profile.igmp_snooping.enabled
+# 3. svi_parent_profile.igmp_snooping.enabled
 
   - profile: igmp_parent_profile_1
-    igmp_snooping_enabled: false
+    igmp_snooping:
+      enabled: false
 
   - profile: igmp_parent_profile_2
-    igmp_snooping_enabled: true
+    igmp_snooping:
+      enabled: true
 
   - profile: igmp_child_profile_1
-    igmp_snooping_enabled: false
+    igmp_snooping:
+      enabled: false
 
   - profile: igmp_child_profile_2
-    igmp_snooping_enabled: true
+    igmp_snooping:
+      enabled: true
     parent_profile: igmp_parent_profile_1
 
   - profile: igmp_child_profile_3
@@ -273,26 +277,27 @@ tenants:
             name: svi_profile_tests_121_description
             profile: struct_config_on_multiple_svis
 
-#### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
+#### ---- Test inheritance of svi igmp_snooping.enabled ----- ###
 # Tests logic for network services: ip igmp snooping
 # Expected result for all tests is that igmp snooping is enabled for all VLANs
 
-          # igmp_snooping_enabled set on svi to true, child_profile and parent_profile set to false
+          # igmp_snooping.enabled set on svi to true, child_profile and parent_profile set to false
           - id: 210
             name: igmp_snooping_enabled_210
             enabled: true
             ip_address_virtual: 10.2.10.1/24
-            igmp_snooping_enabled: true
+            igmp_snooping:
+              enabled: true
             profile: igmp_child_profile_1
 
-          # igmp_snooping_enabled set on child_profile to true and parent_profile set to false
+          # igmp_snooping.enabled set on child_profile to true and parent_profile set to false
           - id: 211
             name: igmp_snooping_enabled_211
             enabled: true
             ip_address_virtual: 10.2.11.1/24
             profile: igmp_child_profile_2
 
-          # igmp_snooping_enabled set on parent_profile to true
+          # igmp_snooping.enabled set on parent_profile to true
           - id: 212
             name: igmp_snooping_enabled_212
             enabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -15,7 +15,8 @@ svi_profiles:
   - profile: WITH_DHCP_AND_SNOOPING
     enabled: true
     ip_address_virtual: 10.1.11.254/24
-    igmp_snooping_enabled: false
+    igmp_snooping:
+      enabled: false
     ip_helpers:
       - ip_helper: 1.1.1.1
         source_interface: lo100
@@ -247,12 +248,14 @@ tenants:
       - id: 160
         name: Tenant_A_VMOTION
         tags: ['opzone']
-        igmp_snooping_enabled: true
+        igmp_snooping:
+          enabled: true
       # L2 vlan as integer
       - id: 161
         name: Tenant_A_NFS
         tags: ['opzone']
-        igmp_snooping_enabled: false
+        igmp_snooping:
+          enabled: false
       - id: 162
         name: Tenant_A_FTP
         tags: ['opzone']

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -15,7 +15,8 @@ svi_profiles:
   - profile: WITH_DHCP_AND_SNOOPING
     enabled: true
     ip_address_virtual: 10.1.11.254/24
-    igmp_snooping_enabled: false
+    igmp_snooping:
+      enabled: false
     ip_helpers:
       - ip_helper: 1.1.1.1
         source_interface: lo100

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
@@ -19,7 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_l2_multicast_group_ipv4_pool</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool") | String |  |  | Format: ipv4_pool | Comma separated list of prefixes (IPv4 address/Mask) or ranges (IPv4_address-IPv4_address). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_l2_multicast_group_ipv4_pool_offset</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool_offset") | Integer |  | `0` |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.fast_leave") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp><network_services_key.key>.igmp_snooping.fast_leave</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.fast_leave") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.fast_leave under the Tenant</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for all SVIs within the Tenant if `evpn_l2_multicast` is True.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN.<br>This can be overridden per SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan_flood_multicast</samp>](## "<network_services_keys.name>.[].vxlan_flood_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vxlan_flood_multicast.enabled") | Boolean | Required |  |  | Enable Flood group Multicast for all SVIs and l2vlans within Tenant. |
@@ -242,7 +242,7 @@
           # Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.
           # This key is deprecated.
           # Support will be removed in AVD version 7.0.0.
-          # Use `<network_services_key.key>.igmp_snooping.fast_leave` instead.
+          # Use `igmp_snooping.fast_leave under the Tenant` instead.
           fast_leave: <bool>
 
           # Always configure `redistribute igmp` under BGP for all SVIs within the Tenant if `evpn_l2_multicast` is True.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "<network_services_keys.name>.[].name") | String | Required, Unique |  |  | Specify a tenant name.<br>Tenant provide a construct to group L3 VRFs and L2 VLANs.<br>Networks services can be filtered by tenant name.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if "evpn_l2_multicast" is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.source_address") | String |  | `main_router_id` |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- `diagnostic_loopback` will configure the VRF Diagnostic Loopback.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the Tenant.<br>On EOS, IGMP fast-leave is enabled on all VLANs by default. |
@@ -77,7 +77,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -98,7 +98,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -118,7 +118,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -138,7 +138,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "l2vlan_profiles.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "l2vlan_profiles.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "l2vlan_profiles.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -163,7 +163,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "svi_profiles.[].nodes.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -184,7 +184,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "svi_profiles.[].igmp_snooping") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "svi_profiles.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if `evpn_l2_multicast` is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
@@ -207,7 +207,7 @@
         igmp_snooping:
           querier:
 
-            # Will be enabled automatically if "evpn_l2_multicast" is enabled.
+            # Will be enabled automatically if `evpn_l2_multicast` is enabled.
             enabled: <bool>
 
             # The value of `source_address` will be interpreted according to these rules:
@@ -434,7 +434,7 @@
                       enabled: <bool>
                       querier:
 
-                        # Will be enabled automatically if evpn_l2_multicast is enabled.
+                        # Will be enabled automatically if `evpn_l2_multicast` is enabled.
                         enabled: <bool>
 
                         # The value of `source_address` will be interpreted according to these rules:
@@ -507,7 +507,7 @@
                   enabled: <bool>
                   querier:
 
-                    # Will be enabled automatically if evpn_l2_multicast is enabled.
+                    # Will be enabled automatically if `evpn_l2_multicast` is enabled.
                     enabled: <bool>
 
                     # The value of `source_address` will be interpreted according to these rules:
@@ -575,7 +575,7 @@
               enabled: <bool>
               querier:
 
-                # Will be enabled automatically if evpn_l2_multicast is enabled.
+                # Will be enabled automatically if `evpn_l2_multicast` is enabled.
                 enabled: <bool>
 
                 # The value of `source_address` will be interpreted according to these rules:
@@ -641,7 +641,7 @@
           enabled: <bool>
           querier:
 
-            # Will be enabled automatically if evpn_l2_multicast is enabled.
+            # Will be enabled automatically if `evpn_l2_multicast` is enabled.
             enabled: <bool>
 
             # The value of `source_address` will be interpreted according to these rules:
@@ -733,7 +733,7 @@
               enabled: <bool>
               querier:
 
-                # Will be enabled automatically if evpn_l2_multicast is enabled.
+                # Will be enabled automatically if `evpn_l2_multicast` is enabled.
                 enabled: <bool>
 
                 # The value of `source_address` will be interpreted according to these rules:
@@ -806,7 +806,7 @@
           enabled: <bool>
           querier:
 
-            # Will be enabled automatically if evpn_l2_multicast is enabled.
+            # Will be enabled automatically if `evpn_l2_multicast` is enabled.
             enabled: <bool>
 
             # The value of `source_address` will be interpreted according to these rules:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
@@ -86,6 +86,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for the VLAN. Overrides the setting of `<network_services_key>.[].evpn_l2_multicast.always_redistribute_igmp`.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN. |
@@ -106,6 +107,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2vlans</samp>](## "<network_services_keys.name>.[].l2vlans") | List, items: Dictionary |  |  |  | Define L2 network services organized by VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].l2vlans.[].id") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "<network_services_keys.name>.[].l2vlans.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, igmp snooping and igmp snooping querier will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
@@ -125,6 +127,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id`, `diagnostic_loopback` and `main_router_id` will configure the Loopback0 IP since there is no VRF tied to an L2VLAN.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>l2vlan_profiles</samp>](## "l2vlan_profiles") | List, items: Dictionary |  |  |  | Profiles to inherit common settings for l2vlans defined under the network_services key. |
     | [<samp>&nbsp;&nbsp;-&nbsp;profile</samp>](## "l2vlan_profiles.[].profile") | String | Required, Unique |  |  | Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "l2vlan_profiles.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, igmp snooping and igmp snooping querier will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
@@ -144,6 +147,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id`, `diagnostic_loopback` and `main_router_id` will configure the Loopback0 IP since there is no VRF tied to an L2VLAN.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>svi_profiles</samp>](## "svi_profiles") | List, items: Dictionary |  |  |  | Profiles to share common settings for SVIs under `<network_services_key>.[].vrfs.svis`.<br>Keys are the same used under SVIs. Keys defined under SVIs take precedence.<br>Note: structured configuration is not merged recursively and will be taken directly from the most specific level in the following order:<br>1. svi.nodes[inventory_hostname].structured_config<br>2. svi_profile.nodes[inventory_hostname].structured_config<br>3. svi_parent_profile.nodes[inventory_hostname].structured_config<br>4. svi.structured_config<br>5. svi_profile.structured_config<br>6. svi_parent_profile.structured_config<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;profile</samp>](## "svi_profiles.[].profile") | String | Required, Unique |  |  | Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "svi_profiles.[].nodes") | List, items: Dictionary |  |  |  | Define node specific configuration, such as unique IP addresses.<br>Any keys set here will be merged onto the SVI config, except `structured_config` keys which will replace the `structured_config` set on SVI level.<br> |
@@ -168,6 +172,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "svi_profiles.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "svi_profiles.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for the VLAN. Overrides the setting of `<network_services_key>.[].evpn_l2_multicast.always_redistribute_igmp`.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN. |
@@ -188,6 +193,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
 
 === "YAML"
 
@@ -469,6 +475,9 @@
                       # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
                       version: <int; 1 | 2 | 3>
 
+                      # Enable IGMP snooping fast-leave feature.
+                      fast_leave: <bool>
+
                 # Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.
                 # When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.
                 # Requires `evpn_multicast` to also be set to `true`.
@@ -539,6 +548,9 @@
                   # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
                   version: <int; 1 | 2 | 3>
 
+                  # Enable IGMP snooping fast-leave feature.
+                  fast_leave: <bool>
+
         # Define L2 network services organized by VLAN ID.
         l2vlans:
 
@@ -602,6 +614,9 @@
               # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
               version: <int; 1 | 2 | 3>
 
+              # Enable IGMP snooping fast-leave feature.
+              fast_leave: <bool>
+
     # Profiles to inherit common settings for l2vlans defined under the network_services key.
     l2vlan_profiles:
 
@@ -664,6 +679,9 @@
 
           # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
           version: <int; 1 | 2 | 3>
+
+          # Enable IGMP snooping fast-leave feature.
+          fast_leave: <bool>
 
     # Profiles to share common settings for SVIs under `<network_services_key>.[].vrfs.svis`.
     # Keys are the same used under SVIs. Keys defined under SVIs take precedence.
@@ -756,6 +774,9 @@
               # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
               version: <int; 1 | 2 | 3>
 
+              # Enable IGMP snooping fast-leave feature.
+              fast_leave: <bool>
+
         # Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.
         # When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.
         # Requires `evpn_multicast` to also be set to `true`.
@@ -825,4 +846,7 @@
 
           # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
           version: <int; 1 | 2 | 3>
+
+          # Enable IGMP snooping fast-leave feature.
+          fast_leave: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
@@ -9,11 +9,17 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>&lt;network_services_keys.name&gt;</samp>](## "<network_services_keys.name>") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "<network_services_keys.name>.[].name") | String | Required, Unique |  |  | Specify a tenant name.<br>Tenant provide a construct to group L3 VRFs and L2 VLANs.<br>Networks services can be filtered by tenant name.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if "evpn_l2_multicast" is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.source_address") | String |  | `main_router_id` |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- `diagnostic_loopback` will configure the VRF Diagnostic Loopback.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the Tenant.<br>On EOS, IGMP fast-leave is enabled on all VLANs by default. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast") | Dictionary |  |  |  | Enable EVPN L2 Multicast for all SVIs and l2vlans within Tenant.<br>- Multicast group binding is created only for Multicast traffic. BULL traffic will use ingress-replication.<br>- Configures binding between VXLAN, VLAN, and multicast group IPv4 address using the following formula:<br>  < evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool > + < vlan_id - 1 > + < evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool_offset >.<br>- The recommendation is to assign a /20 block within the 232.0.0.0/8 Source-Specific Multicast range.<br>- Enables `redistribute igmp` on the router bgp MAC VRF.<br>- When evpn_l2_multicast.enabled is true for a VLAN or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled - overriding those individual settings.<br>- Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_l2_multicast_group_ipv4_pool</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool") | String |  |  | Format: ipv4_pool | Comma separated list of prefixes (IPv4 address/Mask) or ranges (IPv4_address-IPv4_address). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_l2_multicast_group_ipv4_pool_offset</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.underlay_l2_multicast_group_ipv4_pool_offset") | Integer |  | `0` |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.fast_leave") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp><network_services_key.key>.igmp.fast_leave</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.fast_leave") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp><network_services_key.key>.igmp_snooping.fast_leave</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "<network_services_keys.name>.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for all SVIs within the Tenant if `evpn_l2_multicast` is True.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN.<br>This can be overridden per SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan_flood_multicast</samp>](## "<network_services_keys.name>.[].vxlan_flood_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vxlan_flood_multicast.enabled") | Boolean | Required |  |  | Enable Flood group Multicast for all SVIs and l2vlans within Tenant. |
@@ -35,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "<network_services_keys.name>.[].pim_rp_addresses.[].groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].pim_rp_addresses.[].groups.[]") | String |  |  |  | Group_prefix/mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_name</samp>](## "<network_services_keys.name>.[].pim_rp_addresses.[].access_list_name") | String |  |  |  | List of groups to associate with the RP address set in 'rp'.<br>If access_list_name is set, a standard access-list will be configured matching these groups.<br>Otherwise the groups are configured directly on the RP command.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].igmp_snooping_querier") | Dictionary |  |  |  | Enable IGMP snooping querier for each SVI/l2vlan within tenant, by default using IP address of Loopback 0.<br>When enabled, IGMP snooping querier will only be configured on L3 devices, i.e., uplink_type: p2p.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | Enable IGMP snooping querier for each SVI/l2vlan within tenant, by default using IP address of Loopback 0.<br>When enabled, IGMP snooping querier will only be configured on L3 devices, i.e., uplink_type: p2p.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if "evpn_l2_multicast" is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].igmp_snooping_querier.source_address") | String |  | `main_router_id` |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- `diagnostic_loopback` will configure the VRF Diagnostic Loopback.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
@@ -68,12 +74,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l3_multicast</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_l3_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l3_multicast to override setting of `<network_services_key>.[].evpn_l3_multicast.enabled` and `<network_services_key>.[].vrfs.[].evpn_l3_multicast.enabled`.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_l3_multicast.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_enabled") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS).<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.enabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for the VLAN. Overrides the setting of `<network_services_key>.[].evpn_l2_multicast.always_redistribute_igmp`.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN. |
@@ -82,12 +94,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l3_multicast</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l3_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l3_multicast to override setting of `<network_services_key>.[].evpn_l3_multicast.enabled` and `<network_services_key>.[].vrfs.[].evpn_l3_multicast.enabled`.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l3_multicast.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_enabled") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS).<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.enabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2vlans</samp>](## "<network_services_keys.name>.[].l2vlans") | List, items: Dictionary |  |  |  | Define L2 network services organized by VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].l2vlans.[].id") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "<network_services_keys.name>.[].l2vlans.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, igmp snooping and igmp snooping querier will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
@@ -95,12 +113,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan_flood_multicast</samp>](## "<network_services_keys.name>.[].l2vlans.[].vxlan_flood_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].vxlan_flood_multicast.enabled") | Boolean |  |  |  | Explicitly enable or disable vxlan_flood_multicast to override setting of `<network_services_key>.[].vxlan_flood_multicast.enabled`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "<network_services_keys.name>.[].l2vlans.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this VLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier") | Dictionary |  |  |  | Enable igmp snooping querier, by default using IP address of Loopback 0.<br>When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | Enable igmp snooping querier, by default using IP address of Loopback 0.<br>When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id`, `diagnostic_loopback` and `main_router_id` will configure the Loopback0 IP since there is no VRF tied to an L2VLAN.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].l2vlans.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>l2vlan_profiles</samp>](## "l2vlan_profiles") | List, items: Dictionary |  |  |  | Profiles to inherit common settings for l2vlans defined under the network_services key. |
     | [<samp>&nbsp;&nbsp;-&nbsp;profile</samp>](## "l2vlan_profiles.[].profile") | String | Required, Unique |  |  | Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "l2vlan_profiles.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, igmp snooping and igmp snooping querier will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
@@ -108,12 +132,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan_flood_multicast</samp>](## "l2vlan_profiles.[].vxlan_flood_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].vxlan_flood_multicast.enabled") | Boolean |  |  |  | Explicitly enable or disable vxlan_flood_multicast to override setting of `<network_services_key>.[].vxlan_flood_multicast.enabled`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "l2vlan_profiles.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this VLAN. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "l2vlan_profiles.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "l2vlan_profiles.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "l2vlan_profiles.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "l2vlan_profiles.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "l2vlan_profiles.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "l2vlan_profiles.[].igmp_snooping_querier") | Dictionary |  |  |  | Enable igmp snooping querier, by default using IP address of Loopback 0.<br>When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "l2vlan_profiles.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | Enable igmp snooping querier, by default using IP address of Loopback 0.<br>When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id`, `diagnostic_loopback` and `main_router_id` will configure the Loopback0 IP since there is no VRF tied to an L2VLAN.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "l2vlan_profiles.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>svi_profiles</samp>](## "svi_profiles") | List, items: Dictionary |  |  |  | Profiles to share common settings for SVIs under `<network_services_key>.[].vrfs.svis`.<br>Keys are the same used under SVIs. Keys defined under SVIs take precedence.<br>Note: structured configuration is not merged recursively and will be taken directly from the most specific level in the following order:<br>1. svi.nodes[inventory_hostname].structured_config<br>2. svi_profile.nodes[inventory_hostname].structured_config<br>3. svi_parent_profile.nodes[inventory_hostname].structured_config<br>4. svi.structured_config<br>5. svi_profile.structured_config<br>6. svi_parent_profile.structured_config<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;profile</samp>](## "svi_profiles.[].profile") | String | Required, Unique |  |  | Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "svi_profiles.[].nodes") | List, items: Dictionary |  |  |  | Define node specific configuration, such as unique IP addresses.<br>Any keys set here will be merged onto the SVI config, except `structured_config` keys which will replace the `structured_config` set on SVI level.<br> |
@@ -126,12 +156,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "svi_profiles.[].nodes.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l3_multicast</samp>](## "svi_profiles.[].nodes.[].evpn_l3_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l3_multicast to override setting of `<network_services_key>.[].evpn_l3_multicast.enabled` and `<network_services_key>.[].vrfs.[].evpn_l3_multicast.enabled`.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].evpn_l3_multicast.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "svi_profiles.[].nodes.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].nodes.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_enabled") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS).<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.enabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].nodes.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multicast</samp>](## "svi_profiles.[].evpn_l2_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.<br>When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].evpn_l2_multicast.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_redistribute_igmp</samp>](## "svi_profiles.[].evpn_l2_multicast.always_redistribute_igmp") | Boolean |  |  |  | Always configure `redistribute igmp` under BGP for the VLAN. Overrides the setting of `<network_services_key>.[].evpn_l2_multicast.always_redistribute_igmp`.<br>By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.<br>Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,<br>but it is required to support forwarding of TTL=1 multicast traffic within the VLAN. |
@@ -140,12 +176,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;underlay_multicast_group</samp>](## "svi_profiles.[].vxlan_flood_multicast.underlay_multicast_group") | String |  |  |  | Specific multicast group to use for this SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l3_multicast</samp>](## "svi_profiles.[].evpn_l3_multicast") | Dictionary |  |  |  | Explicitly enable or disable evpn_l3_multicast to override setting of `<network_services_key>.[].evpn_l3_multicast.enabled` and `<network_services_key>.[].vrfs.[].evpn_l3_multicast.enabled`.<br>Requires `evpn_multicast` to also be set to `true`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].evpn_l3_multicast.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "svi_profiles.[].igmp_snooping_enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "svi_profiles.[].igmp_snooping_querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping</samp>](## "svi_profiles.[].igmp_snooping") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping.enabled") | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;querier</samp>](## "svi_profiles.[].igmp_snooping.querier") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping.querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].igmp_snooping.querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].igmp_snooping.querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].igmp_snooping.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "svi_profiles.[].igmp_snooping_enabled") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable or disable IGMP snooping (Enabled by default on EOS).<span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.enabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_querier</samp>](## "svi_profiles.[].igmp_snooping_querier") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 7.0.0. Use <samp>igmp_snooping.querier</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].igmp_snooping_querier.enabled") | Boolean |  |  |  | Will be enabled automatically if evpn_l2_multicast is enabled. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping_querier.source_address`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_address</samp>](## "svi_profiles.[].igmp_snooping_querier.source_address") | String |  |  |  | The value of `source_address` will be interpreted according to these rules:<br>- `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.<br>- 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.<br>- `main_router_id` will configure the Loopback0 IP address.<br>- An IPv4 address will be used directly as the source address.<br>Overrides `<network_services_key>[].igmp_snooping.querier.source_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "svi_profiles.[].igmp_snooping_querier.version") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>3</code> | IGMP Version (By default EOS uses IGMP version 2 for IGMP querier). |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "svi_profiles.[].igmp_snooping_querier.fast_leave") | Boolean |  |  |  | Enable IGMP snooping fast-leave feature. |
 
 === "YAML"
 
@@ -156,6 +198,25 @@
         # Tenant provide a construct to group L3 VRFs and L2 VLANs.
         # Networks services can be filtered by tenant name.
       - name: <str; required; unique>
+        igmp_snooping:
+          querier:
+
+            # Will be enabled automatically if "evpn_l2_multicast" is enabled.
+            enabled: <bool>
+
+            # The value of `source_address` will be interpreted according to these rules:
+            # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+            # - `diagnostic_loopback` will configure the VRF Diagnostic Loopback.
+            # - `main_router_id` will configure the Loopback0 IP address.
+            # - An IPv4 address will be used directly as the source address.
+            source_address: <str; default="main_router_id">
+
+            # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+            version: <int; 1 | 2 | 3>
+
+          # Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the Tenant.
+          # On EOS, IGMP fast-leave is enabled on all VLANs by default.
+          fast_leave: <bool>
 
         # Enable EVPN L2 Multicast for all SVIs and l2vlans within Tenant.
         # - Multicast group binding is created only for Multicast traffic. BULL traffic will use ingress-replication.
@@ -175,7 +236,7 @@
           # Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.
           # This key is deprecated.
           # Support will be removed in AVD version 7.0.0.
-          # Use `<network_services_key.key>.igmp.fast_leave` instead.
+          # Use `<network_services_key.key>.igmp_snooping.fast_leave` instead.
           fast_leave: <bool>
 
           # Always configure `redistribute igmp` under BGP for all SVIs within the Tenant if `evpn_l2_multicast` is True.
@@ -251,6 +312,9 @@
 
         # Enable IGMP snooping querier for each SVI/l2vlan within tenant, by default using IP address of Loopback 0.
         # When enabled, IGMP snooping querier will only be configured on L3 devices, i.e., uplink_type: p2p.
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `igmp_snooping.querier` instead.
         igmp_snooping_querier:
 
           # Will be enabled automatically if "evpn_l2_multicast" is enabled.
@@ -358,9 +422,37 @@
                     # Requires `evpn_multicast` to also be set to `true`.
                     evpn_l3_multicast:
                       enabled: <bool>
+                    igmp_snooping:
+
+                      # Enable or disable IGMP snooping (Enabled by default on EOS).
+                      enabled: <bool>
+                      querier:
+
+                        # Will be enabled automatically if evpn_l2_multicast is enabled.
+                        enabled: <bool>
+
+                        # The value of `source_address` will be interpreted according to these rules:
+                        # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                        # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                        # - `main_router_id` will configure the Loopback0 IP address.
+                        # - An IPv4 address will be used directly as the source address.
+                        # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+                        source_address: <str>
+
+                        # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                        version: <int; 1 | 2 | 3>
+
+                      # Enable IGMP snooping fast-leave feature.
+                      fast_leave: <bool>
 
                     # Enable or disable IGMP snooping (Enabled by default on EOS).
+                    # This key is deprecated.
+                    # Support will be removed in AVD version 7.0.0.
+                    # Use `igmp_snooping.enabled` instead.
                     igmp_snooping_enabled: <bool>
+                    # This key is deprecated.
+                    # Support will be removed in AVD version 7.0.0.
+                    # Use `igmp_snooping.querier` instead.
                     igmp_snooping_querier:
 
                       # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -371,14 +463,11 @@
                       # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
                       # - `main_router_id` will configure the Loopback0 IP address.
                       # - An IPv4 address will be used directly as the source address.
-                      # Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.
+                      # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
                       source_address: <str>
 
                       # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
                       version: <int; 1 | 2 | 3>
-
-                      # Enable IGMP snooping fast-leave feature.
-                      fast_leave: <bool>
 
                 # Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.
                 # When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.
@@ -403,9 +492,37 @@
                 # Requires `evpn_multicast` to also be set to `true`.
                 evpn_l3_multicast:
                   enabled: <bool>
+                igmp_snooping:
+
+                  # Enable or disable IGMP snooping (Enabled by default on EOS).
+                  enabled: <bool>
+                  querier:
+
+                    # Will be enabled automatically if evpn_l2_multicast is enabled.
+                    enabled: <bool>
+
+                    # The value of `source_address` will be interpreted according to these rules:
+                    # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                    # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                    # - `main_router_id` will configure the Loopback0 IP address.
+                    # - An IPv4 address will be used directly as the source address.
+                    # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+                    source_address: <str>
+
+                    # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                    version: <int; 1 | 2 | 3>
+
+                  # Enable IGMP snooping fast-leave feature.
+                  fast_leave: <bool>
 
                 # Enable or disable IGMP snooping (Enabled by default on EOS).
+                # This key is deprecated.
+                # Support will be removed in AVD version 7.0.0.
+                # Use `igmp_snooping.enabled` instead.
                 igmp_snooping_enabled: <bool>
+                # This key is deprecated.
+                # Support will be removed in AVD version 7.0.0.
+                # Use `igmp_snooping.querier` instead.
                 igmp_snooping_querier:
 
                   # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -416,14 +533,11 @@
                   # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
                   # - `main_router_id` will configure the Loopback0 IP address.
                   # - An IPv4 address will be used directly as the source address.
-                  # Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.
+                  # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
                   source_address: <str>
 
                   # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
                   version: <int; 1 | 2 | 3>
-
-                  # Enable IGMP snooping fast-leave feature.
-                  fast_leave: <bool>
 
         # Define L2 network services organized by VLAN ID.
         l2vlans:
@@ -443,12 +557,37 @@
 
               # Specific multicast group to use for this VLAN.
               underlay_multicast_group: <str>
+            igmp_snooping:
+
+              # Enable or disable IGMP snooping (Enabled by default on EOS).
+              enabled: <bool>
+              querier:
+
+                # Will be enabled automatically if evpn_l2_multicast is enabled.
+                enabled: <bool>
+
+                # The value of `source_address` will be interpreted according to these rules:
+                # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                # - `main_router_id` will configure the Loopback0 IP address.
+                # - An IPv4 address will be used directly as the source address.
+                # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+                source_address: <str>
+
+                # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                version: <int; 1 | 2 | 3>
+
+              # Enable IGMP snooping fast-leave feature.
+              fast_leave: <bool>
 
             # Enable or disable IGMP snooping (Enabled by default on EOS).
             igmp_snooping_enabled: <bool>
 
             # Enable igmp snooping querier, by default using IP address of Loopback 0.
             # When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.
+            # This key is deprecated.
+            # Support will be removed in AVD version 7.0.0.
+            # Use `igmp_snooping.querier` instead.
             igmp_snooping_querier:
 
               # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -462,9 +601,6 @@
 
               # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
               version: <int; 1 | 2 | 3>
-
-              # Enable IGMP snooping fast-leave feature.
-              fast_leave: <bool>
 
     # Profiles to inherit common settings for l2vlans defined under the network_services key.
     l2vlan_profiles:
@@ -484,12 +620,37 @@
 
           # Specific multicast group to use for this VLAN.
           underlay_multicast_group: <str>
+        igmp_snooping:
+
+          # Enable or disable IGMP snooping (Enabled by default on EOS).
+          enabled: <bool>
+          querier:
+
+            # Will be enabled automatically if evpn_l2_multicast is enabled.
+            enabled: <bool>
+
+            # The value of `source_address` will be interpreted according to these rules:
+            # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+            # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+            # - `main_router_id` will configure the Loopback0 IP address.
+            # - An IPv4 address will be used directly as the source address.
+            # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+            source_address: <str>
+
+            # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+            version: <int; 1 | 2 | 3>
+
+          # Enable IGMP snooping fast-leave feature.
+          fast_leave: <bool>
 
         # Enable or disable IGMP snooping (Enabled by default on EOS).
         igmp_snooping_enabled: <bool>
 
         # Enable igmp snooping querier, by default using IP address of Loopback 0.
         # When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `igmp_snooping.querier` instead.
         igmp_snooping_querier:
 
           # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -503,9 +664,6 @@
 
           # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
           version: <int; 1 | 2 | 3>
-
-          # Enable IGMP snooping fast-leave feature.
-          fast_leave: <bool>
 
     # Profiles to share common settings for SVIs under `<network_services_key>.[].vrfs.svis`.
     # Keys are the same used under SVIs. Keys defined under SVIs take precedence.
@@ -551,9 +709,37 @@
             # Requires `evpn_multicast` to also be set to `true`.
             evpn_l3_multicast:
               enabled: <bool>
+            igmp_snooping:
+
+              # Enable or disable IGMP snooping (Enabled by default on EOS).
+              enabled: <bool>
+              querier:
+
+                # Will be enabled automatically if evpn_l2_multicast is enabled.
+                enabled: <bool>
+
+                # The value of `source_address` will be interpreted according to these rules:
+                # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                # - `main_router_id` will configure the Loopback0 IP address.
+                # - An IPv4 address will be used directly as the source address.
+                # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+                source_address: <str>
+
+                # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                version: <int; 1 | 2 | 3>
+
+              # Enable IGMP snooping fast-leave feature.
+              fast_leave: <bool>
 
             # Enable or disable IGMP snooping (Enabled by default on EOS).
+            # This key is deprecated.
+            # Support will be removed in AVD version 7.0.0.
+            # Use `igmp_snooping.enabled` instead.
             igmp_snooping_enabled: <bool>
+            # This key is deprecated.
+            # Support will be removed in AVD version 7.0.0.
+            # Use `igmp_snooping.querier` instead.
             igmp_snooping_querier:
 
               # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -564,14 +750,11 @@
               # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
               # - `main_router_id` will configure the Loopback0 IP address.
               # - An IPv4 address will be used directly as the source address.
-              # Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.
+              # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
               source_address: <str>
 
               # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
               version: <int; 1 | 2 | 3>
-
-              # Enable IGMP snooping fast-leave feature.
-              fast_leave: <bool>
 
         # Explicitly enable or disable evpn_l2_multicast to override setting of `<network_services_key>.[].evpn_l2_multicast.enabled`.
         # When evpn_l2_multicast.enabled is set to true for a vlan or a tenant, "igmp snooping" and "igmp snooping querier" will always be enabled, overriding those individual settings.
@@ -596,9 +779,37 @@
         # Requires `evpn_multicast` to also be set to `true`.
         evpn_l3_multicast:
           enabled: <bool>
+        igmp_snooping:
+
+          # Enable or disable IGMP snooping (Enabled by default on EOS).
+          enabled: <bool>
+          querier:
+
+            # Will be enabled automatically if evpn_l2_multicast is enabled.
+            enabled: <bool>
+
+            # The value of `source_address` will be interpreted according to these rules:
+            # - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+            # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+            # - `main_router_id` will configure the Loopback0 IP address.
+            # - An IPv4 address will be used directly as the source address.
+            # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+            source_address: <str>
+
+            # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+            version: <int; 1 | 2 | 3>
+
+          # Enable IGMP snooping fast-leave feature.
+          fast_leave: <bool>
 
         # Enable or disable IGMP snooping (Enabled by default on EOS).
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `igmp_snooping.enabled` instead.
         igmp_snooping_enabled: <bool>
+        # This key is deprecated.
+        # Support will be removed in AVD version 7.0.0.
+        # Use `igmp_snooping.querier` instead.
         igmp_snooping_querier:
 
           # Will be enabled automatically if evpn_l2_multicast is enabled.
@@ -609,12 +820,9 @@
           # - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
           # - `main_router_id` will configure the Loopback0 IP address.
           # - An IPv4 address will be used directly as the source address.
-          # Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.
+          # Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
           source_address: <str>
 
           # IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
           version: <int; 1 | 2 | 3>
-
-          # Enable IGMP snooping fast-leave feature.
-          fast_leave: <bool>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services.md
@@ -13,8 +13,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_vrf_id_base</samp>](## "<network_services_keys.name>.[].mac_vrf_id_base") | Integer |  |  | Min: 0<br>Max: 16770000 | If not set, "mac_vrf_vni_base" will be used.<br>Base number for MAC VRF RD/RT ID (Required unless mac_vrf_vni_base is set)<br>ID is derived from the base number with simple addition.<br>i.e. mac_vrf_id_base = 10000, svi 100 = RD/RT 10100, svi 300 = RD/RT 10300.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_aware_bundle_number_base</samp>](## "<network_services_keys.name>.[].vlan_aware_bundle_number_base") | Integer |  | `0` |  | Base number for VLAN aware bundle RD/RT.<br>The "Assigned Number" part of RD/RT is derived from vrf_vni + vlan_aware_bundle_number_base.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_vlan_bundle</samp>](## "<network_services_keys.name>.[].evpn_vlan_bundle") | String |  |  |  | Enable `evpn_vlan_bundle` for all l2vlans and SVIs under the tenant. This `evpn_vlan_bundle` should be present in `evpn_vlan_bundles`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;igmp</samp>](## "<network_services_keys.name>.[].igmp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fast_leave</samp>](## "<network_services_keys.name>.[].igmp.fast_leave") | Boolean |  |  |  | Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the Tenant.<br>On EOS, IGMP fast-leave is enabled on all VLANs by default. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].evpn_l2_multi_domain") | Boolean |  | `True` |  | Explicitly extend all VLANs/VLAN-Aware Bundles inside the tenant to remote EVPN domains. |
 
 === "YAML"
@@ -44,11 +42,6 @@
 
         # Enable `evpn_vlan_bundle` for all l2vlans and SVIs under the tenant. This `evpn_vlan_bundle` should be present in `evpn_vlan_bundles`.
         evpn_vlan_bundle: <str>
-        igmp:
-
-          # Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the Tenant.
-          # On EOS, IGMP fast-leave is enabled on all VLANs by default.
-          fast_leave: <bool>
 
         # Explicitly extend all VLANs/VLAN-Aware Bundles inside the tenant to remote EVPN domains.
         evpn_l2_multi_domain: <bool; default=True>

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20020,11 +20020,101 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
+        class IgmpSnooping(AvdModel):
+            """Subclass of AvdModel."""
+
+            class Querier(AvdModel):
+                """Subclass of AvdModel."""
+
+                Version: TypeAlias = Literal[1, 2, 3]
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                enabled: bool | None
+                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                source_address: str | None
+                """
+                The value of `source_address` will be interpreted according to these rules:
+                - `vrf_router_id` will
+                configure the VRF router ID address according to
+                `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                - 'diagnostic_loopback' will configure the
+                VRF Diagnostic Loopback address.
+                - `main_router_id` will configure the Loopback0 IP address.
+                - An
+                IPv4 address will be used directly as the source address.
+                Overrides
+                `<network_services_key>[].igmp_snooping.querier.source_address`.
+                """
+                version: Version | None
+                """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        enabled: bool | None | UndefinedType = Undefined,
+                        source_address: str | None | UndefinedType = Undefined,
+                        version: Version | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        Querier.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                            source_address:
+                               The value of `source_address` will be interpreted according to these rules:
+                               - `vrf_router_id` will
+                               configure the VRF router ID address according to
+                               `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                               - 'diagnostic_loopback' will configure the
+                               VRF Diagnostic Loopback address.
+                               - `main_router_id` will configure the Loopback0 IP address.
+                               - An
+                               IPv4 address will be used directly as the source address.
+                               Overrides
+                               `<network_services_key>[].igmp_snooping.querier.source_address`.
+                            version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                        """
+
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+            enabled: bool | None
+            """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+            querier: Querier
+            """Subclass of AvdModel."""
+            fast_leave: bool | None
+            """Enable IGMP snooping fast-leave feature."""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    enabled: bool | None | UndefinedType = Undefined,
+                    querier: Querier | UndefinedType = Undefined,
+                    fast_leave: bool | None | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    IgmpSnooping.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                        querier: Subclass of AvdModel.
+                        fast_leave: Enable IGMP snooping fast-leave feature.
+
+                    """
+
         class IgmpSnoopingQuerier(AvdModel):
             """Subclass of AvdModel."""
 
             Version: TypeAlias = Literal[1, 2, 3]
-            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
             enabled: bool | None
             """Will be enabled automatically if evpn_l2_multicast is enabled."""
             source_address: str | None
@@ -20039,8 +20129,6 @@ class EosDesigns(EosDesignsRootModel):
             """
             version: Version | None
             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-            fast_leave: bool | None
-            """Enable IGMP snooping fast-leave feature."""
 
             if TYPE_CHECKING:
 
@@ -20050,7 +20138,6 @@ class EosDesigns(EosDesignsRootModel):
                     enabled: bool | None | UndefinedType = Undefined,
                     source_address: str | None | UndefinedType = Undefined,
                     version: Version | None | UndefinedType = Undefined,
-                    fast_leave: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     IgmpSnoopingQuerier.
@@ -20069,7 +20156,6 @@ class EosDesigns(EosDesignsRootModel):
                            Overrides
                            `<network_services_key>[].igmp_snooping_querier.source_address`.
                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                     """
 
@@ -20154,6 +20240,7 @@ class EosDesigns(EosDesignsRootModel):
             "evpn_l2_multi_domain": {"type": bool},
             "evpn_l2_multicast": {"type": EvpnL2Multicast},
             "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
+            "igmp_snooping": {"type": IgmpSnooping},
             "igmp_snooping_enabled": {"type": bool},
             "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
             "bgp": {"type": Bgp},
@@ -20243,6 +20330,8 @@ class EosDesigns(EosDesignsRootModel):
         """
         vxlan_flood_multicast: VxlanFloodMulticast
         """Subclass of AvdModel."""
+        igmp_snooping: IgmpSnooping
+        """Subclass of AvdModel."""
         igmp_snooping_enabled: bool | None
         """Enable or disable IGMP snooping (Enabled by default on EOS)."""
         igmp_snooping_querier: IgmpSnoopingQuerier
@@ -20277,6 +20366,7 @@ class EosDesigns(EosDesignsRootModel):
                 evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
                 evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                 vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
+                igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                 igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                 igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                 bgp: Bgp | UndefinedType = Undefined,
@@ -20349,6 +20439,7 @@ class EosDesigns(EosDesignsRootModel):
                        Subclass of
                        AvdModel.
                     vxlan_flood_multicast: Subclass of AvdModel.
+                    igmp_snooping: Subclass of AvdModel.
                     igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                     igmp_snooping_querier:
                        Enable igmp snooping querier, by default using IP address of Loopback 0.
@@ -31402,11 +31493,101 @@ class EosDesigns(EosDesignsRootModel):
 
                         """
 
+            class IgmpSnooping(AvdModel):
+                """Subclass of AvdModel."""
+
+                class Querier(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    Version: TypeAlias = Literal[1, 2, 3]
+                    _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                    enabled: bool | None
+                    """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                    source_address: str | None
+                    """
+                    The value of `source_address` will be interpreted according to these rules:
+                    - `vrf_router_id` will
+                    configure the VRF router ID address according to
+                    `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                    - 'diagnostic_loopback' will configure the
+                    VRF Diagnostic Loopback address.
+                    - `main_router_id` will configure the Loopback0 IP address.
+                    - An
+                    IPv4 address will be used directly as the source address.
+                    Overrides
+                    `<network_services_key>[].igmp_snooping.querier.source_address`.
+                    """
+                    version: Version | None
+                    """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                    if TYPE_CHECKING:
+
+                        def __init__(
+                            self,
+                            *,
+                            enabled: bool | None | UndefinedType = Undefined,
+                            source_address: str | None | UndefinedType = Undefined,
+                            version: Version | None | UndefinedType = Undefined,
+                        ) -> None:
+                            """
+                            Querier.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                source_address:
+                                   The value of `source_address` will be interpreted according to these rules:
+                                   - `vrf_router_id` will
+                                   configure the VRF router ID address according to
+                                   `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                   - 'diagnostic_loopback' will configure the
+                                   VRF Diagnostic Loopback address.
+                                   - `main_router_id` will configure the Loopback0 IP address.
+                                   - An
+                                   IPv4 address will be used directly as the source address.
+                                   Overrides
+                                   `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                            """
+
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+                enabled: bool | None
+                """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+                querier: Querier
+                """Subclass of AvdModel."""
+                fast_leave: bool | None
+                """Enable IGMP snooping fast-leave feature."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        enabled: bool | None | UndefinedType = Undefined,
+                        querier: Querier | UndefinedType = Undefined,
+                        fast_leave: bool | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        IgmpSnooping.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                            querier: Subclass of AvdModel.
+                            fast_leave: Enable IGMP snooping fast-leave feature.
+
+                        """
+
             class IgmpSnoopingQuerier(AvdModel):
                 """Subclass of AvdModel."""
 
                 Version: TypeAlias = Literal[1, 2, 3]
-                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                 enabled: bool | None
                 """Will be enabled automatically if evpn_l2_multicast is enabled."""
                 source_address: str | None
@@ -31421,12 +31602,10 @@ class EosDesigns(EosDesignsRootModel):
                 - An
                 IPv4 address will be used directly as the source address.
                 Overrides
-                `<network_services_key>[].igmp_snooping_querier.source_address`.
+                `<network_services_key>[].igmp_snooping.querier.source_address`.
                 """
                 version: Version | None
                 """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-                fast_leave: bool | None
-                """Enable IGMP snooping fast-leave feature."""
 
                 if TYPE_CHECKING:
 
@@ -31436,7 +31615,6 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool | None | UndefinedType = Undefined,
                         source_address: str | None | UndefinedType = Undefined,
                         version: Version | None | UndefinedType = Undefined,
-                        fast_leave: bool | None | UndefinedType = Undefined,
                     ) -> None:
                         """
                         IgmpSnoopingQuerier.
@@ -31457,9 +31635,8 @@ class EosDesigns(EosDesignsRootModel):
                                - An
                                IPv4 address will be used directly as the source address.
                                Overrides
-                               `<network_services_key>[].igmp_snooping_querier.source_address`.
+                               `<network_services_key>[].igmp_snooping.querier.source_address`.
                             version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                            fast_leave: Enable IGMP snooping fast-leave feature.
 
                         """
 
@@ -31668,6 +31845,7 @@ class EosDesigns(EosDesignsRootModel):
                 "evpn_l2_multicast": {"type": EvpnL2Multicast},
                 "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                 "evpn_l3_multicast": {"type": EvpnL3Multicast},
+                "igmp_snooping": {"type": IgmpSnooping},
                 "igmp_snooping_enabled": {"type": bool},
                 "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
                 "vxlan": {"type": bool, "default": True},
@@ -31837,6 +32015,8 @@ class EosDesigns(EosDesignsRootModel):
 
             Subclass of AvdModel.
             """
+            igmp_snooping: IgmpSnooping
+            """Subclass of AvdModel."""
             igmp_snooping_enabled: bool | None
             """Enable or disable IGMP snooping (Enabled by default on EOS)."""
             igmp_snooping_querier: IgmpSnoopingQuerier
@@ -31911,6 +32091,7 @@ class EosDesigns(EosDesignsRootModel):
                     evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                     vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                     evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
+                    igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                     igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                     igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                     vxlan: bool | UndefinedType = Undefined,
@@ -32045,6 +32226,7 @@ class EosDesigns(EosDesignsRootModel):
 
 
                            Subclass of AvdModel.
+                        igmp_snooping: Subclass of AvdModel.
                         igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                         igmp_snooping_querier: Subclass of AvdModel.
                         vxlan: Extend this SVI over VXLAN.
@@ -32399,11 +32581,101 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
+        class IgmpSnooping(AvdModel):
+            """Subclass of AvdModel."""
+
+            class Querier(AvdModel):
+                """Subclass of AvdModel."""
+
+                Version: TypeAlias = Literal[1, 2, 3]
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                enabled: bool | None
+                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                source_address: str | None
+                """
+                The value of `source_address` will be interpreted according to these rules:
+                - `vrf_router_id` will
+                configure the VRF router ID address according to
+                `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                - 'diagnostic_loopback' will configure the
+                VRF Diagnostic Loopback address.
+                - `main_router_id` will configure the Loopback0 IP address.
+                - An
+                IPv4 address will be used directly as the source address.
+                Overrides
+                `<network_services_key>[].igmp_snooping.querier.source_address`.
+                """
+                version: Version | None
+                """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        enabled: bool | None | UndefinedType = Undefined,
+                        source_address: str | None | UndefinedType = Undefined,
+                        version: Version | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        Querier.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                            source_address:
+                               The value of `source_address` will be interpreted according to these rules:
+                               - `vrf_router_id` will
+                               configure the VRF router ID address according to
+                               `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                               - 'diagnostic_loopback' will configure the
+                               VRF Diagnostic Loopback address.
+                               - `main_router_id` will configure the Loopback0 IP address.
+                               - An
+                               IPv4 address will be used directly as the source address.
+                               Overrides
+                               `<network_services_key>[].igmp_snooping.querier.source_address`.
+                            version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                        """
+
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+            enabled: bool | None
+            """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+            querier: Querier
+            """Subclass of AvdModel."""
+            fast_leave: bool | None
+            """Enable IGMP snooping fast-leave feature."""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    enabled: bool | None | UndefinedType = Undefined,
+                    querier: Querier | UndefinedType = Undefined,
+                    fast_leave: bool | None | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    IgmpSnooping.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                        querier: Subclass of AvdModel.
+                        fast_leave: Enable IGMP snooping fast-leave feature.
+
+                    """
+
         class IgmpSnoopingQuerier(AvdModel):
             """Subclass of AvdModel."""
 
             Version: TypeAlias = Literal[1, 2, 3]
-            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
             enabled: bool | None
             """Will be enabled automatically if evpn_l2_multicast is enabled."""
             source_address: str | None
@@ -32418,12 +32690,10 @@ class EosDesigns(EosDesignsRootModel):
             - An
             IPv4 address will be used directly as the source address.
             Overrides
-            `<network_services_key>[].igmp_snooping_querier.source_address`.
+            `<network_services_key>[].igmp_snooping.querier.source_address`.
             """
             version: Version | None
             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-            fast_leave: bool | None
-            """Enable IGMP snooping fast-leave feature."""
 
             if TYPE_CHECKING:
 
@@ -32433,7 +32703,6 @@ class EosDesigns(EosDesignsRootModel):
                     enabled: bool | None | UndefinedType = Undefined,
                     source_address: str | None | UndefinedType = Undefined,
                     version: Version | None | UndefinedType = Undefined,
-                    fast_leave: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     IgmpSnoopingQuerier.
@@ -32454,9 +32723,8 @@ class EosDesigns(EosDesignsRootModel):
                            - An
                            IPv4 address will be used directly as the source address.
                            Overrides
-                           `<network_services_key>[].igmp_snooping_querier.source_address`.
+                           `<network_services_key>[].igmp_snooping.querier.source_address`.
                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                     """
 
@@ -32667,6 +32935,7 @@ class EosDesigns(EosDesignsRootModel):
             "evpn_l2_multicast": {"type": EvpnL2Multicast},
             "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
             "evpn_l3_multicast": {"type": EvpnL3Multicast},
+            "igmp_snooping": {"type": IgmpSnooping},
             "igmp_snooping_enabled": {"type": bool},
             "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
             "vxlan": {"type": bool, "default": True},
@@ -32852,6 +33121,8 @@ class EosDesigns(EosDesignsRootModel):
 
         Subclass of AvdModel.
         """
+        igmp_snooping: IgmpSnooping
+        """Subclass of AvdModel."""
         igmp_snooping_enabled: bool | None
         """Enable or disable IGMP snooping (Enabled by default on EOS)."""
         igmp_snooping_querier: IgmpSnoopingQuerier
@@ -32928,6 +33199,7 @@ class EosDesigns(EosDesignsRootModel):
                 evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                 vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                 evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
+                igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                 igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                 igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                 vxlan: bool | UndefinedType = Undefined,
@@ -33074,6 +33346,7 @@ class EosDesigns(EosDesignsRootModel):
 
 
                        Subclass of AvdModel.
+                    igmp_snooping: Subclass of AvdModel.
                     igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                     igmp_snooping_querier: Subclass of AvdModel.
                     vxlan: Extend this SVI over VXLAN.
@@ -60249,10 +60522,71 @@ class EosDesigns(EosDesignsRootModel):
 
                 BgpPeerGroups._item_type = BgpPeerGroupsItem
 
-                class Igmp(AvdModel):
+                class IgmpSnooping(AvdModel):
                     """Subclass of AvdModel."""
 
-                    _fields: ClassVar[dict] = {"fast_leave": {"type": bool}}
+                    class Querier(AvdModel):
+                        """Subclass of AvdModel."""
+
+                        Version: TypeAlias = Literal[1, 2, 3]
+                        _fields: ClassVar[dict] = {
+                            "enabled": {"type": bool},
+                            "source_address": {"type": str, "default": "main_router_id"},
+                            "version": {"type": int},
+                        }
+                        enabled: bool | None
+                        """Will be enabled automatically if "evpn_l2_multicast" is enabled."""
+                        source_address: str
+                        """
+                        The value of `source_address` will be interpreted according to these rules:
+                        - `vrf_router_id` will
+                        configure the VRF router ID address according to
+                        `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                        - `diagnostic_loopback` will configure the
+                        VRF Diagnostic Loopback.
+                        - `main_router_id` will configure the Loopback0 IP address.
+                        - An IPv4
+                        address will be used directly as the source address.
+
+                        Default value: `"main_router_id"`
+                        """
+                        version: Version | None
+                        """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                        if TYPE_CHECKING:
+
+                            def __init__(
+                                self,
+                                *,
+                                enabled: bool | None | UndefinedType = Undefined,
+                                source_address: str | UndefinedType = Undefined,
+                                version: Version | None | UndefinedType = Undefined,
+                            ) -> None:
+                                """
+                                Querier.
+
+
+                                Subclass of AvdModel.
+
+                                Args:
+                                    enabled: Will be enabled automatically if "evpn_l2_multicast" is enabled.
+                                    source_address:
+                                       The value of `source_address` will be interpreted according to these rules:
+                                       - `vrf_router_id` will
+                                       configure the VRF router ID address according to
+                                       `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                       - `diagnostic_loopback` will configure the
+                                       VRF Diagnostic Loopback.
+                                       - `main_router_id` will configure the Loopback0 IP address.
+                                       - An IPv4
+                                       address will be used directly as the source address.
+                                    version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                                """
+
+                    _fields: ClassVar[dict] = {"querier": {"type": Querier}, "fast_leave": {"type": bool}}
+                    querier: Querier
+                    """Subclass of AvdModel."""
                     fast_leave: bool | None
                     """
                     Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the
@@ -60262,14 +60596,15 @@ class EosDesigns(EosDesignsRootModel):
 
                     if TYPE_CHECKING:
 
-                        def __init__(self, *, fast_leave: bool | None | UndefinedType = Undefined) -> None:
+                        def __init__(self, *, querier: Querier | UndefinedType = Undefined, fast_leave: bool | None | UndefinedType = Undefined) -> None:
                             """
-                            Igmp.
+                            IgmpSnooping.
 
 
                             Subclass of AvdModel.
 
                             Args:
+                                querier: Subclass of AvdModel.
                                 fast_leave:
                                    Explicitly enable or disable IGMP snooping fast-leave feature for all SVIs and L2 VLANs within the
                                    Tenant.
@@ -61623,16 +61958,101 @@ class EosDesigns(EosDesignsRootModel):
 
                                         """
 
+                            class IgmpSnooping(AvdModel):
+                                """Subclass of AvdModel."""
+
+                                class Querier(AvdModel):
+                                    """Subclass of AvdModel."""
+
+                                    Version: TypeAlias = Literal[1, 2, 3]
+                                    _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                                    enabled: bool | None
+                                    """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                                    source_address: str | None
+                                    """
+                                    The value of `source_address` will be interpreted according to these rules:
+                                    - `vrf_router_id` will
+                                    configure the VRF router ID address according to
+                                    `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                    - 'diagnostic_loopback' will configure the
+                                    VRF Diagnostic Loopback address.
+                                    - `main_router_id` will configure the Loopback0 IP address.
+                                    - An
+                                    IPv4 address will be used directly as the source address.
+                                    Overrides
+                                    `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                    """
+                                    version: Version | None
+                                    """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                                    if TYPE_CHECKING:
+
+                                        def __init__(
+                                            self,
+                                            *,
+                                            enabled: bool | None | UndefinedType = Undefined,
+                                            source_address: str | None | UndefinedType = Undefined,
+                                            version: Version | None | UndefinedType = Undefined,
+                                        ) -> None:
+                                            """
+                                            Querier.
+
+
+                                            Subclass of AvdModel.
+
+                                            Args:
+                                                enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                                source_address:
+                                                   The value of `source_address` will be interpreted according to these rules:
+                                                   - `vrf_router_id` will
+                                                   configure the VRF router ID address according to
+                                                   `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                                   - 'diagnostic_loopback' will configure the
+                                                   VRF Diagnostic Loopback address.
+                                                   - `main_router_id` will configure the Loopback0 IP address.
+                                                   - An
+                                                   IPv4 address will be used directly as the source address.
+                                                   Overrides
+                                                   `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                                version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                                            """
+
+                                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+                                enabled: bool | None
+                                """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+                                querier: Querier
+                                """Subclass of AvdModel."""
+                                fast_leave: bool | None
+                                """Enable IGMP snooping fast-leave feature."""
+
+                                if TYPE_CHECKING:
+
+                                    def __init__(
+                                        self,
+                                        *,
+                                        enabled: bool | None | UndefinedType = Undefined,
+                                        querier: Querier | UndefinedType = Undefined,
+                                        fast_leave: bool | None | UndefinedType = Undefined,
+                                    ) -> None:
+                                        """
+                                        IgmpSnooping.
+
+
+                                        Subclass of AvdModel.
+
+                                        Args:
+                                            enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                                            querier: Subclass of AvdModel.
+                                            fast_leave: Enable IGMP snooping fast-leave feature.
+
+                                        """
+
                             class IgmpSnoopingQuerier(AvdModel):
                                 """Subclass of AvdModel."""
 
                                 Version: TypeAlias = Literal[1, 2, 3]
-                                _fields: ClassVar[dict] = {
-                                    "enabled": {"type": bool},
-                                    "source_address": {"type": str},
-                                    "version": {"type": int},
-                                    "fast_leave": {"type": bool},
-                                }
+                                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                                 enabled: bool | None
                                 """Will be enabled automatically if evpn_l2_multicast is enabled."""
                                 source_address: str | None
@@ -61647,12 +62067,10 @@ class EosDesigns(EosDesignsRootModel):
                                 - An
                                 IPv4 address will be used directly as the source address.
                                 Overrides
-                                `<network_services_key>[].igmp_snooping_querier.source_address`.
+                                `<network_services_key>[].igmp_snooping.querier.source_address`.
                                 """
                                 version: Version | None
                                 """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-                                fast_leave: bool | None
-                                """Enable IGMP snooping fast-leave feature."""
 
                                 if TYPE_CHECKING:
 
@@ -61662,7 +62080,6 @@ class EosDesigns(EosDesignsRootModel):
                                         enabled: bool | None | UndefinedType = Undefined,
                                         source_address: str | None | UndefinedType = Undefined,
                                         version: Version | None | UndefinedType = Undefined,
-                                        fast_leave: bool | None | UndefinedType = Undefined,
                                     ) -> None:
                                         """
                                         IgmpSnoopingQuerier.
@@ -61683,9 +62100,8 @@ class EosDesigns(EosDesignsRootModel):
                                                - An
                                                IPv4 address will be used directly as the source address.
                                                Overrides
-                                               `<network_services_key>[].igmp_snooping_querier.source_address`.
+                                               `<network_services_key>[].igmp_snooping.querier.source_address`.
                                             version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                                            fast_leave: Enable IGMP snooping fast-leave feature.
 
                                         """
 
@@ -61895,6 +62311,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "evpn_l2_multicast": {"type": EvpnL2Multicast},
                                 "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                                 "evpn_l3_multicast": {"type": EvpnL3Multicast},
+                                "igmp_snooping": {"type": IgmpSnooping},
                                 "igmp_snooping_enabled": {"type": bool},
                                 "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
                                 "vxlan": {"type": bool, "default": True},
@@ -62074,6 +62491,8 @@ class EosDesigns(EosDesignsRootModel):
 
                             Subclass of AvdModel.
                             """
+                            igmp_snooping: IgmpSnooping
+                            """Subclass of AvdModel."""
                             igmp_snooping_enabled: bool | None
                             """Enable or disable IGMP snooping (Enabled by default on EOS)."""
                             igmp_snooping_querier: IgmpSnoopingQuerier
@@ -62149,6 +62568,7 @@ class EosDesigns(EosDesignsRootModel):
                                     evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                                     vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                                     evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
+                                    igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                                     igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                                     igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                                     vxlan: bool | UndefinedType = Undefined,
@@ -62289,6 +62709,7 @@ class EosDesigns(EosDesignsRootModel):
 
 
                                            Subclass of AvdModel.
+                                        igmp_snooping: Subclass of AvdModel.
                                         igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                                         igmp_snooping_querier: Subclass of AvdModel.
                                         vxlan: Extend this SVI over VXLAN.
@@ -62647,16 +63068,101 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
+                        class IgmpSnooping(AvdModel):
+                            """Subclass of AvdModel."""
+
+                            class Querier(AvdModel):
+                                """Subclass of AvdModel."""
+
+                                Version: TypeAlias = Literal[1, 2, 3]
+                                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                                enabled: bool | None
+                                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                                source_address: str | None
+                                """
+                                The value of `source_address` will be interpreted according to these rules:
+                                - `vrf_router_id` will
+                                configure the VRF router ID address according to
+                                `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                - 'diagnostic_loopback' will configure the
+                                VRF Diagnostic Loopback address.
+                                - `main_router_id` will configure the Loopback0 IP address.
+                                - An
+                                IPv4 address will be used directly as the source address.
+                                Overrides
+                                `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                """
+                                version: Version | None
+                                """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                                if TYPE_CHECKING:
+
+                                    def __init__(
+                                        self,
+                                        *,
+                                        enabled: bool | None | UndefinedType = Undefined,
+                                        source_address: str | None | UndefinedType = Undefined,
+                                        version: Version | None | UndefinedType = Undefined,
+                                    ) -> None:
+                                        """
+                                        Querier.
+
+
+                                        Subclass of AvdModel.
+
+                                        Args:
+                                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                            source_address:
+                                               The value of `source_address` will be interpreted according to these rules:
+                                               - `vrf_router_id` will
+                                               configure the VRF router ID address according to
+                                               `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                               - 'diagnostic_loopback' will configure the
+                                               VRF Diagnostic Loopback address.
+                                               - `main_router_id` will configure the Loopback0 IP address.
+                                               - An
+                                               IPv4 address will be used directly as the source address.
+                                               Overrides
+                                               `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                            version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                                        """
+
+                            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+                            enabled: bool | None
+                            """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+                            querier: Querier
+                            """Subclass of AvdModel."""
+                            fast_leave: bool | None
+                            """Enable IGMP snooping fast-leave feature."""
+
+                            if TYPE_CHECKING:
+
+                                def __init__(
+                                    self,
+                                    *,
+                                    enabled: bool | None | UndefinedType = Undefined,
+                                    querier: Querier | UndefinedType = Undefined,
+                                    fast_leave: bool | None | UndefinedType = Undefined,
+                                ) -> None:
+                                    """
+                                    IgmpSnooping.
+
+
+                                    Subclass of AvdModel.
+
+                                    Args:
+                                        enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                                        querier: Subclass of AvdModel.
+                                        fast_leave: Enable IGMP snooping fast-leave feature.
+
+                                    """
+
                         class IgmpSnoopingQuerier(AvdModel):
                             """Subclass of AvdModel."""
 
                             Version: TypeAlias = Literal[1, 2, 3]
-                            _fields: ClassVar[dict] = {
-                                "enabled": {"type": bool},
-                                "source_address": {"type": str},
-                                "version": {"type": int},
-                                "fast_leave": {"type": bool},
-                            }
+                            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                             enabled: bool | None
                             """Will be enabled automatically if evpn_l2_multicast is enabled."""
                             source_address: str | None
@@ -62671,12 +63177,10 @@ class EosDesigns(EosDesignsRootModel):
                             - An
                             IPv4 address will be used directly as the source address.
                             Overrides
-                            `<network_services_key>[].igmp_snooping_querier.source_address`.
+                            `<network_services_key>[].igmp_snooping.querier.source_address`.
                             """
                             version: Version | None
                             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-                            fast_leave: bool | None
-                            """Enable IGMP snooping fast-leave feature."""
 
                             if TYPE_CHECKING:
 
@@ -62686,7 +63190,6 @@ class EosDesigns(EosDesignsRootModel):
                                     enabled: bool | None | UndefinedType = Undefined,
                                     source_address: str | None | UndefinedType = Undefined,
                                     version: Version | None | UndefinedType = Undefined,
-                                    fast_leave: bool | None | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     IgmpSnoopingQuerier.
@@ -62707,9 +63210,8 @@ class EosDesigns(EosDesignsRootModel):
                                            - An
                                            IPv4 address will be used directly as the source address.
                                            Overrides
-                                           `<network_services_key>[].igmp_snooping_querier.source_address`.
+                                           `<network_services_key>[].igmp_snooping.querier.source_address`.
                                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                                     """
 
@@ -62923,6 +63425,7 @@ class EosDesigns(EosDesignsRootModel):
                             "evpn_l2_multicast": {"type": EvpnL2Multicast},
                             "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                             "evpn_l3_multicast": {"type": EvpnL3Multicast},
+                            "igmp_snooping": {"type": IgmpSnooping},
                             "igmp_snooping_enabled": {"type": bool},
                             "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
                             "vxlan": {"type": bool, "default": True},
@@ -63132,6 +63635,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
+                        igmp_snooping: IgmpSnooping
+                        """Subclass of AvdModel."""
                         igmp_snooping_enabled: bool | None
                         """Enable or disable IGMP snooping (Enabled by default on EOS)."""
                         igmp_snooping_querier: IgmpSnoopingQuerier
@@ -63211,6 +63716,7 @@ class EosDesigns(EosDesignsRootModel):
                                 evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                                 vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                                 evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
+                                igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                                 igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                                 igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                                 vxlan: bool | UndefinedType = Undefined,
@@ -63373,6 +63879,7 @@ class EosDesigns(EosDesignsRootModel):
 
 
                                        Subclass of AvdModel.
+                                    igmp_snooping: Subclass of AvdModel.
                                     igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                                     igmp_snooping_querier: Subclass of AvdModel.
                                     vxlan: Extend this SVI over VXLAN.
@@ -67222,16 +67729,101 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
+                    class IgmpSnooping(AvdModel):
+                        """Subclass of AvdModel."""
+
+                        class Querier(AvdModel):
+                            """Subclass of AvdModel."""
+
+                            Version: TypeAlias = Literal[1, 2, 3]
+                            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                            enabled: bool | None
+                            """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                            source_address: str | None
+                            """
+                            The value of `source_address` will be interpreted according to these rules:
+                            - `vrf_router_id` will
+                            configure the VRF router ID address according to
+                            `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                            - 'diagnostic_loopback' will configure the
+                            VRF Diagnostic Loopback address.
+                            - `main_router_id` will configure the Loopback0 IP address.
+                            - An
+                            IPv4 address will be used directly as the source address.
+                            Overrides
+                            `<network_services_key>[].igmp_snooping.querier.source_address`.
+                            """
+                            version: Version | None
+                            """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+
+                            if TYPE_CHECKING:
+
+                                def __init__(
+                                    self,
+                                    *,
+                                    enabled: bool | None | UndefinedType = Undefined,
+                                    source_address: str | None | UndefinedType = Undefined,
+                                    version: Version | None | UndefinedType = Undefined,
+                                ) -> None:
+                                    """
+                                    Querier.
+
+
+                                    Subclass of AvdModel.
+
+                                    Args:
+                                        enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                        source_address:
+                                           The value of `source_address` will be interpreted according to these rules:
+                                           - `vrf_router_id` will
+                                           configure the VRF router ID address according to
+                                           `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                                           - 'diagnostic_loopback' will configure the
+                                           VRF Diagnostic Loopback address.
+                                           - `main_router_id` will configure the Loopback0 IP address.
+                                           - An
+                                           IPv4 address will be used directly as the source address.
+                                           Overrides
+                                           `<network_services_key>[].igmp_snooping.querier.source_address`.
+                                        version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+
+                                    """
+
+                        _fields: ClassVar[dict] = {"enabled": {"type": bool}, "querier": {"type": Querier}, "fast_leave": {"type": bool}}
+                        enabled: bool | None
+                        """Enable or disable IGMP snooping (Enabled by default on EOS)."""
+                        querier: Querier
+                        """Subclass of AvdModel."""
+                        fast_leave: bool | None
+                        """Enable IGMP snooping fast-leave feature."""
+
+                        if TYPE_CHECKING:
+
+                            def __init__(
+                                self,
+                                *,
+                                enabled: bool | None | UndefinedType = Undefined,
+                                querier: Querier | UndefinedType = Undefined,
+                                fast_leave: bool | None | UndefinedType = Undefined,
+                            ) -> None:
+                                """
+                                IgmpSnooping.
+
+
+                                Subclass of AvdModel.
+
+                                Args:
+                                    enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
+                                    querier: Subclass of AvdModel.
+                                    fast_leave: Enable IGMP snooping fast-leave feature.
+
+                                """
+
                     class IgmpSnoopingQuerier(AvdModel):
                         """Subclass of AvdModel."""
 
                         Version: TypeAlias = Literal[1, 2, 3]
-                        _fields: ClassVar[dict] = {
-                            "enabled": {"type": bool},
-                            "source_address": {"type": str},
-                            "version": {"type": int},
-                            "fast_leave": {"type": bool},
-                        }
+                        _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                         enabled: bool | None
                         """Will be enabled automatically if evpn_l2_multicast is enabled."""
                         source_address: str | None
@@ -67246,8 +67838,6 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         version: Version | None
                         """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
-                        fast_leave: bool | None
-                        """Enable IGMP snooping fast-leave feature."""
 
                         if TYPE_CHECKING:
 
@@ -67257,7 +67847,6 @@ class EosDesigns(EosDesignsRootModel):
                                 enabled: bool | None | UndefinedType = Undefined,
                                 source_address: str | None | UndefinedType = Undefined,
                                 version: Version | None | UndefinedType = Undefined,
-                                fast_leave: bool | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 IgmpSnoopingQuerier.
@@ -67276,7 +67865,6 @@ class EosDesigns(EosDesignsRootModel):
                                        Overrides
                                        `<network_services_key>[].igmp_snooping_querier.source_address`.
                                     version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
-                                    fast_leave: Enable IGMP snooping fast-leave feature.
 
                                 """
 
@@ -67363,6 +67951,7 @@ class EosDesigns(EosDesignsRootModel):
                         "evpn_l2_multi_domain": {"type": bool},
                         "evpn_l2_multicast": {"type": EvpnL2Multicast},
                         "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
+                        "igmp_snooping": {"type": IgmpSnooping},
                         "igmp_snooping_enabled": {"type": bool},
                         "igmp_snooping_querier": {"type": IgmpSnoopingQuerier},
                         "bgp": {"type": Bgp},
@@ -67465,6 +68054,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     vxlan_flood_multicast: VxlanFloodMulticast
                     """Subclass of AvdModel."""
+                    igmp_snooping: IgmpSnooping
+                    """Subclass of AvdModel."""
                     igmp_snooping_enabled: bool | None
                     """Enable or disable IGMP snooping (Enabled by default on EOS)."""
                     igmp_snooping_querier: IgmpSnoopingQuerier
@@ -67501,6 +68092,7 @@ class EosDesigns(EosDesignsRootModel):
                             evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
                             evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                             vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
+                            igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                             igmp_snooping_enabled: bool | None | UndefinedType = Undefined,
                             igmp_snooping_querier: IgmpSnoopingQuerier | UndefinedType = Undefined,
                             bgp: Bgp | UndefinedType = Undefined,
@@ -67581,6 +68173,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Subclass of
                                    AvdModel.
                                 vxlan_flood_multicast: Subclass of AvdModel.
+                                igmp_snooping: Subclass of AvdModel.
                                 igmp_snooping_enabled: Enable or disable IGMP snooping (Enabled by default on EOS).
                                 igmp_snooping_querier:
                                    Enable igmp snooping querier, by default using IP address of Loopback 0.
@@ -67872,7 +68465,7 @@ class EosDesigns(EosDesignsRootModel):
                     "redistribute_mlag_ibgp_peering_vrfs": {"type": bool, "default": False},
                     "evpn_vlan_bundle": {"type": str},
                     "bgp_peer_groups": {"type": BgpPeerGroups},
-                    "igmp": {"type": Igmp},
+                    "igmp_snooping": {"type": IgmpSnooping},
                     "evpn_l2_multicast": {"type": EvpnL2Multicast},
                     "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                     "evpn_l3_multicast": {"type": EvpnL3Multicast},
@@ -67963,7 +68556,7 @@ class EosDesigns(EosDesignsRootModel):
                 Subclass of
                 AvdIndexedList with `BgpPeerGroupsItem` items. Primary key is `name` (`str`).
                 """
-                igmp: Igmp
+                igmp_snooping: IgmpSnooping
                 """Subclass of AvdModel."""
                 evpn_l2_multicast: EvpnL2Multicast
                 """
@@ -68095,7 +68688,7 @@ class EosDesigns(EosDesignsRootModel):
                         redistribute_mlag_ibgp_peering_vrfs: bool | UndefinedType = Undefined,
                         evpn_vlan_bundle: str | None | UndefinedType = Undefined,
                         bgp_peer_groups: BgpPeerGroups | UndefinedType = Undefined,
-                        igmp: Igmp | UndefinedType = Undefined,
+                        igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
                         evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
                         vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                         evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
@@ -68169,7 +68762,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                Subclass of
                                AvdIndexedList with `BgpPeerGroupsItem` items. Primary key is `name` (`str`).
-                            igmp: Subclass of AvdModel.
+                            igmp_snooping: Subclass of AvdModel.
                             evpn_l2_multicast:
                                Enable EVPN L2 Multicast for all SVIs and l2vlans within Tenant.
                                - Multicast group binding is

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20114,7 +20114,7 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdModel."""
 
             Version: TypeAlias = Literal[1, 2, 3]
-            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
             enabled: bool | None
             """Will be enabled automatically if evpn_l2_multicast is enabled."""
             source_address: str | None
@@ -20129,6 +20129,8 @@ class EosDesigns(EosDesignsRootModel):
             """
             version: Version | None
             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+            fast_leave: bool | None
+            """Enable IGMP snooping fast-leave feature."""
 
             if TYPE_CHECKING:
 
@@ -20138,6 +20140,7 @@ class EosDesigns(EosDesignsRootModel):
                     enabled: bool | None | UndefinedType = Undefined,
                     source_address: str | None | UndefinedType = Undefined,
                     version: Version | None | UndefinedType = Undefined,
+                    fast_leave: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     IgmpSnoopingQuerier.
@@ -20156,6 +20159,7 @@ class EosDesigns(EosDesignsRootModel):
                            Overrides
                            `<network_services_key>[].igmp_snooping_querier.source_address`.
                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                     """
 
@@ -31587,7 +31591,7 @@ class EosDesigns(EosDesignsRootModel):
                 """Subclass of AvdModel."""
 
                 Version: TypeAlias = Literal[1, 2, 3]
-                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
                 enabled: bool | None
                 """Will be enabled automatically if evpn_l2_multicast is enabled."""
                 source_address: str | None
@@ -31606,6 +31610,8 @@ class EosDesigns(EosDesignsRootModel):
                 """
                 version: Version | None
                 """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+                fast_leave: bool | None
+                """Enable IGMP snooping fast-leave feature."""
 
                 if TYPE_CHECKING:
 
@@ -31615,6 +31621,7 @@ class EosDesigns(EosDesignsRootModel):
                         enabled: bool | None | UndefinedType = Undefined,
                         source_address: str | None | UndefinedType = Undefined,
                         version: Version | None | UndefinedType = Undefined,
+                        fast_leave: bool | None | UndefinedType = Undefined,
                     ) -> None:
                         """
                         IgmpSnoopingQuerier.
@@ -31637,6 +31644,7 @@ class EosDesigns(EosDesignsRootModel):
                                Overrides
                                `<network_services_key>[].igmp_snooping.querier.source_address`.
                             version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                            fast_leave: Enable IGMP snooping fast-leave feature.
 
                         """
 
@@ -32675,7 +32683,7 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdModel."""
 
             Version: TypeAlias = Literal[1, 2, 3]
-            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}, "fast_leave": {"type": bool}}
             enabled: bool | None
             """Will be enabled automatically if evpn_l2_multicast is enabled."""
             source_address: str | None
@@ -32694,6 +32702,8 @@ class EosDesigns(EosDesignsRootModel):
             """
             version: Version | None
             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+            fast_leave: bool | None
+            """Enable IGMP snooping fast-leave feature."""
 
             if TYPE_CHECKING:
 
@@ -32703,6 +32713,7 @@ class EosDesigns(EosDesignsRootModel):
                     enabled: bool | None | UndefinedType = Undefined,
                     source_address: str | None | UndefinedType = Undefined,
                     version: Version | None | UndefinedType = Undefined,
+                    fast_leave: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     IgmpSnoopingQuerier.
@@ -32725,6 +32736,7 @@ class EosDesigns(EosDesignsRootModel):
                            Overrides
                            `<network_services_key>[].igmp_snooping.querier.source_address`.
                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                     """
 
@@ -62052,7 +62064,12 @@ class EosDesigns(EosDesignsRootModel):
                                 """Subclass of AvdModel."""
 
                                 Version: TypeAlias = Literal[1, 2, 3]
-                                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                                _fields: ClassVar[dict] = {
+                                    "enabled": {"type": bool},
+                                    "source_address": {"type": str},
+                                    "version": {"type": int},
+                                    "fast_leave": {"type": bool},
+                                }
                                 enabled: bool | None
                                 """Will be enabled automatically if evpn_l2_multicast is enabled."""
                                 source_address: str | None
@@ -62071,6 +62088,8 @@ class EosDesigns(EosDesignsRootModel):
                                 """
                                 version: Version | None
                                 """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+                                fast_leave: bool | None
+                                """Enable IGMP snooping fast-leave feature."""
 
                                 if TYPE_CHECKING:
 
@@ -62080,6 +62099,7 @@ class EosDesigns(EosDesignsRootModel):
                                         enabled: bool | None | UndefinedType = Undefined,
                                         source_address: str | None | UndefinedType = Undefined,
                                         version: Version | None | UndefinedType = Undefined,
+                                        fast_leave: bool | None | UndefinedType = Undefined,
                                     ) -> None:
                                         """
                                         IgmpSnoopingQuerier.
@@ -62102,6 +62122,7 @@ class EosDesigns(EosDesignsRootModel):
                                                Overrides
                                                `<network_services_key>[].igmp_snooping.querier.source_address`.
                                             version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                                            fast_leave: Enable IGMP snooping fast-leave feature.
 
                                         """
 
@@ -63162,7 +63183,12 @@ class EosDesigns(EosDesignsRootModel):
                             """Subclass of AvdModel."""
 
                             Version: TypeAlias = Literal[1, 2, 3]
-                            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                            _fields: ClassVar[dict] = {
+                                "enabled": {"type": bool},
+                                "source_address": {"type": str},
+                                "version": {"type": int},
+                                "fast_leave": {"type": bool},
+                            }
                             enabled: bool | None
                             """Will be enabled automatically if evpn_l2_multicast is enabled."""
                             source_address: str | None
@@ -63181,6 +63207,8 @@ class EosDesigns(EosDesignsRootModel):
                             """
                             version: Version | None
                             """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+                            fast_leave: bool | None
+                            """Enable IGMP snooping fast-leave feature."""
 
                             if TYPE_CHECKING:
 
@@ -63190,6 +63218,7 @@ class EosDesigns(EosDesignsRootModel):
                                     enabled: bool | None | UndefinedType = Undefined,
                                     source_address: str | None | UndefinedType = Undefined,
                                     version: Version | None | UndefinedType = Undefined,
+                                    fast_leave: bool | None | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     IgmpSnoopingQuerier.
@@ -63212,6 +63241,7 @@ class EosDesigns(EosDesignsRootModel):
                                            Overrides
                                            `<network_services_key>[].igmp_snooping.querier.source_address`.
                                         version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                                        fast_leave: Enable IGMP snooping fast-leave feature.
 
                                     """
 
@@ -67823,7 +67853,12 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdModel."""
 
                         Version: TypeAlias = Literal[1, 2, 3]
-                        _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
+                        _fields: ClassVar[dict] = {
+                            "enabled": {"type": bool},
+                            "source_address": {"type": str},
+                            "version": {"type": int},
+                            "fast_leave": {"type": bool},
+                        }
                         enabled: bool | None
                         """Will be enabled automatically if evpn_l2_multicast is enabled."""
                         source_address: str | None
@@ -67838,6 +67873,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         version: Version | None
                         """IGMP Version (By default EOS uses IGMP version 2 for IGMP querier)."""
+                        fast_leave: bool | None
+                        """Enable IGMP snooping fast-leave feature."""
 
                         if TYPE_CHECKING:
 
@@ -67847,6 +67884,7 @@ class EosDesigns(EosDesignsRootModel):
                                 enabled: bool | None | UndefinedType = Undefined,
                                 source_address: str | None | UndefinedType = Undefined,
                                 version: Version | None | UndefinedType = Undefined,
+                                fast_leave: bool | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 IgmpSnoopingQuerier.
@@ -67865,6 +67903,7 @@ class EosDesigns(EosDesignsRootModel):
                                        Overrides
                                        `<network_services_key>[].igmp_snooping_querier.source_address`.
                                     version: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                                    fast_leave: Enable IGMP snooping fast-leave feature.
 
                                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20029,7 +20029,7 @@ class EosDesigns(EosDesignsRootModel):
                 Version: TypeAlias = Literal[1, 2, 3]
                 _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                 enabled: bool | None
-                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                 source_address: str | None
                 """
                 The value of `source_address` will be interpreted according to these rules:
@@ -20063,7 +20063,7 @@ class EosDesigns(EosDesignsRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                            enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                             source_address:
                                The value of `source_address` will be interpreted according to these rules:
                                - `vrf_router_id` will
@@ -31506,7 +31506,7 @@ class EosDesigns(EosDesignsRootModel):
                     Version: TypeAlias = Literal[1, 2, 3]
                     _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                     enabled: bool | None
-                    """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                    """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                     source_address: str | None
                     """
                     The value of `source_address` will be interpreted according to these rules:
@@ -31540,7 +31540,7 @@ class EosDesigns(EosDesignsRootModel):
                             Subclass of AvdModel.
 
                             Args:
-                                enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                                 source_address:
                                    The value of `source_address` will be interpreted according to these rules:
                                    - `vrf_router_id` will
@@ -32598,7 +32598,7 @@ class EosDesigns(EosDesignsRootModel):
                 Version: TypeAlias = Literal[1, 2, 3]
                 _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                 enabled: bool | None
-                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                 source_address: str | None
                 """
                 The value of `source_address` will be interpreted according to these rules:
@@ -32632,7 +32632,7 @@ class EosDesigns(EosDesignsRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                            enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                             source_address:
                                The value of `source_address` will be interpreted according to these rules:
                                - `vrf_router_id` will
@@ -60547,7 +60547,7 @@ class EosDesigns(EosDesignsRootModel):
                             "version": {"type": int},
                         }
                         enabled: bool | None
-                        """Will be enabled automatically if "evpn_l2_multicast" is enabled."""
+                        """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                         source_address: str
                         """
                         The value of `source_address` will be interpreted according to these rules:
@@ -60581,7 +60581,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    enabled: Will be enabled automatically if "evpn_l2_multicast" is enabled.
+                                    enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                                     source_address:
                                        The value of `source_address` will be interpreted according to these rules:
                                        - `vrf_router_id` will
@@ -61979,7 +61979,7 @@ class EosDesigns(EosDesignsRootModel):
                                     Version: TypeAlias = Literal[1, 2, 3]
                                     _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                                     enabled: bool | None
-                                    """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                                    """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                                     source_address: str | None
                                     """
                                     The value of `source_address` will be interpreted according to these rules:
@@ -62013,7 +62013,7 @@ class EosDesigns(EosDesignsRootModel):
                                             Subclass of AvdModel.
 
                                             Args:
-                                                enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                                enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                                                 source_address:
                                                    The value of `source_address` will be interpreted according to these rules:
                                                    - `vrf_router_id` will
@@ -63098,7 +63098,7 @@ class EosDesigns(EosDesignsRootModel):
                                 Version: TypeAlias = Literal[1, 2, 3]
                                 _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                                 enabled: bool | None
-                                """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                                """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                                 source_address: str | None
                                 """
                                 The value of `source_address` will be interpreted according to these rules:
@@ -63132,7 +63132,7 @@ class EosDesigns(EosDesignsRootModel):
                                         Subclass of AvdModel.
 
                                         Args:
-                                            enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                            enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                                             source_address:
                                                The value of `source_address` will be interpreted according to these rules:
                                                - `vrf_router_id` will
@@ -67768,7 +67768,7 @@ class EosDesigns(EosDesignsRootModel):
                             Version: TypeAlias = Literal[1, 2, 3]
                             _fields: ClassVar[dict] = {"enabled": {"type": bool}, "source_address": {"type": str}, "version": {"type": int}}
                             enabled: bool | None
-                            """Will be enabled automatically if evpn_l2_multicast is enabled."""
+                            """Will be enabled automatically if `evpn_l2_multicast` is enabled."""
                             source_address: str | None
                             """
                             The value of `source_address` will be interpreted according to these rules:
@@ -67802,7 +67802,7 @@ class EosDesigns(EosDesignsRootModel):
                                     Subclass of AvdModel.
 
                                     Args:
-                                        enabled: Will be enabled automatically if evpn_l2_multicast is enabled.
+                                        enabled: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                                         source_address:
                                            The value of `source_address` will be interpreted according to these rules:
                                            - `vrf_router_id` will

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7643,6 +7643,51 @@ $defs:
             underlay_multicast_group:
               description: Specific multicast group to use for this VLAN.
               type: str
+        igmp_snooping:
+          type: dict
+          documentation_options:
+            table: network-services-multicast-settings
+          keys:
+            enabled:
+              type: bool
+              description: Enable or disable IGMP snooping (Enabled by default on
+                EOS).
+            querier:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                  description: Will be enabled automatically if evpn_l2_multicast
+                    is enabled.
+                source_address:
+                  type: str
+                  description: 'The value of `source_address` will be interpreted
+                    according to these rules:
+
+                    - `vrf_router_id` will configure the VRF router ID address according
+                    to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+
+                    - ''diagnostic_loopback'' will configure the VRF Diagnostic Loopback
+                    address.
+
+                    - `main_router_id` will configure the Loopback0 IP address.
+
+                    - An IPv4 address will be used directly as the source address.
+
+                    Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.'
+                version:
+                  type: int
+                  description: IGMP Version (By default EOS uses IGMP version 2 for
+                    IGMP querier).
+                  convert_types:
+                  - str
+                  valid_values:
+                  - 1
+                  - 2
+                  - 3
+            fast_leave:
+              type: bool
+              description: Enable IGMP snooping fast-leave feature.
         igmp_snooping_enabled:
           documentation_options:
             table: network-services-multicast-settings
@@ -7652,6 +7697,11 @@ $defs:
           documentation_options:
             table: network-services-multicast-settings
           type: dict
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 7.0.0
+            new_key: igmp_snooping.querier
           description: 'Enable igmp snooping querier, by default using IP address
             of Loopback 0.
 
@@ -7684,9 +7734,6 @@ $defs:
               - 1
               - 2
               - 3
-            fast_leave:
-              type: bool
-              description: Enable IGMP snooping fast-leave feature.
         bgp:
           type: dict
           keys:
@@ -8075,9 +8122,42 @@ $defs:
                   prefix_list_out:
                     type: str
                     description: Outbound prefix-list name.
-        igmp:
+        igmp_snooping:
+          documentation_options:
+            table: network-services-multicast-settings
           type: dict
           keys:
+            querier:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                  description: Will be enabled automatically if "evpn_l2_multicast"
+                    is enabled.
+                source_address:
+                  type: str
+                  description: 'The value of `source_address` will be interpreted
+                    according to these rules:
+
+                    - `vrf_router_id` will configure the VRF router ID address according
+                    to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+
+                    - `diagnostic_loopback` will configure the VRF Diagnostic Loopback.
+
+                    - `main_router_id` will configure the Loopback0 IP address.
+
+                    - An IPv4 address will be used directly as the source address.'
+                  default: main_router_id
+                version:
+                  type: int
+                  description: IGMP Version (By default EOS uses IGMP version 2 for
+                    IGMP querier).
+                  convert_types:
+                  - str
+                  valid_values:
+                  - 1
+                  - 2
+                  - 3
             fast_leave:
               type: bool
               description: 'Explicitly enable or disable IGMP snooping fast-leave
@@ -8118,7 +8198,7 @@ $defs:
                 warning: true
                 removed: false
                 remove_in_version: 7.0.0
-                new_key: <network_services_key.key>.igmp.fast_leave
+                new_key: <network_services_key.key>.igmp_snooping.fast_leave
               description: Enable IGMP snooping fast-leave feature for all SVIs and
                 l2vlans within the Tenant.
             always_redistribute_igmp:
@@ -8272,6 +8352,11 @@ $defs:
 
             '
           type: dict
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 7.0.0
+            new_key: igmp_snooping.querier
           keys:
             enabled:
               type: bool
@@ -14048,15 +14133,69 @@ $defs:
         keys:
           enabled:
             type: bool
+      igmp_snooping:
+        type: dict
+        documentation_options:
+          table: network-services-multicast-settings
+        keys:
+          enabled:
+            type: bool
+            description: Enable or disable IGMP snooping (Enabled by default on EOS).
+          querier:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+                description: Will be enabled automatically if evpn_l2_multicast is
+                  enabled.
+              source_address:
+                type: str
+                description: 'The value of `source_address` will be interpreted according
+                  to these rules:
+
+                  - `vrf_router_id` will configure the VRF router ID address according
+                  to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+
+                  - ''diagnostic_loopback'' will configure the VRF Diagnostic Loopback
+                  address.
+
+                  - `main_router_id` will configure the Loopback0 IP address.
+
+                  - An IPv4 address will be used directly as the source address.
+
+                  Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.'
+              version:
+                type: int
+                description: IGMP Version (By default EOS uses IGMP version 2 for
+                  IGMP querier).
+                convert_types:
+                - str
+                valid_values:
+                - 1
+                - 2
+                - 3
+          fast_leave:
+            type: bool
+            description: Enable IGMP snooping fast-leave feature.
       igmp_snooping_enabled:
         documentation_options:
           table: network-services-multicast-settings
         type: bool
         description: Enable or disable IGMP snooping (Enabled by default on EOS).
+        deprecation:
+          warning: true
+          removed: false
+          remove_in_version: 7.0.0
+          new_key: igmp_snooping.enabled
       igmp_snooping_querier:
         documentation_options:
           table: network-services-multicast-settings
         type: dict
+        deprecation:
+          warning: true
+          removed: false
+          remove_in_version: 7.0.0
+          new_key: igmp_snooping.querier
         keys:
           enabled:
             type: bool
@@ -14076,7 +14215,7 @@ $defs:
 
               - An IPv4 address will be used directly as the source address.
 
-              Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.'
+              Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.'
           version:
             type: int
             description: IGMP Version (By default EOS uses IGMP version 2 for IGMP
@@ -14087,9 +14226,6 @@ $defs:
             - 1
             - 2
             - 3
-          fast_leave:
-            type: bool
-            description: Enable IGMP snooping fast-leave feature.
       vxlan:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7734,6 +7734,9 @@ $defs:
               - 1
               - 2
               - 3
+            fast_leave:
+              type: bool
+              description: Enable IGMP snooping fast-leave feature.
         bgp:
           type: dict
           keys:
@@ -14226,6 +14229,9 @@ $defs:
             - 1
             - 2
             - 3
+          fast_leave:
+            type: bool
+            description: Enable IGMP snooping fast-leave feature.
       vxlan:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7657,7 +7657,7 @@ $defs:
               keys:
                 enabled:
                   type: bool
-                  description: Will be enabled automatically if evpn_l2_multicast
+                  description: Will be enabled automatically if `evpn_l2_multicast`
                     is enabled.
                 source_address:
                   type: str
@@ -8135,7 +8135,7 @@ $defs:
               keys:
                 enabled:
                   type: bool
-                  description: Will be enabled automatically if "evpn_l2_multicast"
+                  description: Will be enabled automatically if `evpn_l2_multicast`
                     is enabled.
                 source_address:
                   type: str
@@ -14149,8 +14149,8 @@ $defs:
             keys:
               enabled:
                 type: bool
-                description: Will be enabled automatically if evpn_l2_multicast is
-                  enabled.
+                description: Will be enabled automatically if `evpn_l2_multicast`
+                  is enabled.
               source_address:
                 type: str
                 description: 'The value of `source_address` will be interpreted according

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -8201,7 +8201,7 @@ $defs:
                 warning: true
                 removed: false
                 remove_in_version: 7.0.0
-                new_key: <network_services_key.key>.igmp_snooping.fast_leave
+                new_key: igmp_snooping.fast_leave under the Tenant
               description: Enable IGMP snooping fast-leave feature for all SVIs and
                 l2vlans within the Tenant.
             always_redistribute_igmp:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
@@ -110,7 +110,7 @@ $defs:
               keys:
                 enabled:
                   type: bool
-                  description: Will be enabled automatically if evpn_l2_multicast is enabled.
+                  description: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                 source_address:
                   type: str
                   description: |-

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
@@ -97,6 +97,41 @@ $defs:
             underlay_multicast_group:
               description: Specific multicast group to use for this VLAN.
               type: str
+        igmp_snooping:
+          type: dict
+          documentation_options:
+            table: network-services-multicast-settings
+          keys:
+            enabled:
+              type: bool
+              description: Enable or disable IGMP snooping (Enabled by default on EOS).
+            querier:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                  description: Will be enabled automatically if evpn_l2_multicast is enabled.
+                source_address:
+                  type: str
+                  description: |-
+                    The value of `source_address` will be interpreted according to these rules:
+                    - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                    - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                    - `main_router_id` will configure the Loopback0 IP address.
+                    - An IPv4 address will be used directly as the source address.
+                    Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+                version:
+                  type: int
+                  description: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                  convert_types:
+                    - str
+                  valid_values:
+                    - 1
+                    - 2
+                    - 3
+            fast_leave:
+              type: bool
+              description: Enable IGMP snooping fast-leave feature.
         igmp_snooping_enabled:
           documentation_options:
             table: network-services-multicast-settings
@@ -106,6 +141,11 @@ $defs:
           documentation_options:
             table: network-services-multicast-settings
           type: dict
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 7.0.0
+            new_key: igmp_snooping.querier
           description: |
             Enable igmp snooping querier, by default using IP address of Loopback 0.
             When enabled, igmp snooping querier will only be configured on l3 devices, i.e., uplink_type: p2p.
@@ -129,9 +169,6 @@ $defs:
                 - 1
                 - 2
                 - 3
-            fast_leave:
-              type: bool
-              description: Enable IGMP snooping fast-leave feature.
         bgp:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l2vlans.schema.yml
@@ -169,6 +169,9 @@ $defs:
                 - 1
                 - 2
                 - 3
+            fast_leave:
+              type: bool
+              description: Enable IGMP snooping fast-leave feature.
         bgp:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -244,7 +244,7 @@ $defs:
                 warning: true
                 removed: false
                 remove_in_version: 7.0.0
-                new_key: <network_services_key.key>.igmp_snooping.fast_leave
+                new_key: igmp_snooping.fast_leave under the Tenant
               description: Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.
             always_redistribute_igmp:
               type: bool

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -177,9 +177,35 @@ $defs:
                   prefix_list_out:
                     type: str
                     description: Outbound prefix-list name.
-        igmp:
+        igmp_snooping:
+          documentation_options:
+            table: network-services-multicast-settings
           type: dict
           keys:
+            querier:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                  description: Will be enabled automatically if "evpn_l2_multicast" is enabled.
+                source_address:
+                  type: str
+                  description: |-
+                    The value of `source_address` will be interpreted according to these rules:
+                    - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                    - `diagnostic_loopback` will configure the VRF Diagnostic Loopback.
+                    - `main_router_id` will configure the Loopback0 IP address.
+                    - An IPv4 address will be used directly as the source address.
+                  default: main_router_id
+                version:
+                  type: int
+                  description: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                  convert_types:
+                    - str
+                  valid_values:
+                    - 1
+                    - 2
+                    - 3
             fast_leave:
               type: bool
               description: |-
@@ -218,7 +244,7 @@ $defs:
                 warning: true
                 removed: false
                 remove_in_version: 7.0.0
-                new_key: <network_services_key.key>.igmp.fast_leave
+                new_key: <network_services_key.key>.igmp_snooping.fast_leave
               description: Enable IGMP snooping fast-leave feature for all SVIs and l2vlans within the Tenant.
             always_redistribute_igmp:
               type: bool
@@ -340,6 +366,11 @@ $defs:
             Enable IGMP snooping querier for each SVI/l2vlan within tenant, by default using IP address of Loopback 0.
             When enabled, IGMP snooping querier will only be configured on L3 devices, i.e., uplink_type: p2p.
           type: dict
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 7.0.0
+            new_key: igmp_snooping.querier
           keys:
             enabled:
               type: bool

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -187,7 +187,7 @@ $defs:
               keys:
                 enabled:
                   type: bool
-                  description: Will be enabled automatically if "evpn_l2_multicast" is enabled.
+                  description: Will be enabled automatically if `evpn_l2_multicast` is enabled.
                 source_address:
                   type: str
                   description: |-

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -292,6 +292,9 @@ $defs:
               - 1
               - 2
               - 3
+          fast_leave:
+            type: bool
+            description: Enable IGMP snooping fast-leave feature.
       vxlan:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -229,7 +229,7 @@ $defs:
             keys:
               enabled:
                 type: bool
-                description: Will be enabled automatically if evpn_l2_multicast is enabled.
+                description: Will be enabled automatically if `evpn_l2_multicast` is enabled.
               source_address:
                 type: str
                 description: |-

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -216,15 +216,60 @@ $defs:
         keys:
           enabled:
             type: bool
+      igmp_snooping:
+        type: dict
+        documentation_options:
+          table: network-services-multicast-settings
+        keys:
+          enabled:
+            type: bool
+            description: Enable or disable IGMP snooping (Enabled by default on EOS).
+          querier:
+            type: dict
+            keys:
+              enabled:
+                type: bool
+                description: Will be enabled automatically if evpn_l2_multicast is enabled.
+              source_address:
+                type: str
+                description: |-
+                  The value of `source_address` will be interpreted according to these rules:
+                  - `vrf_router_id` will configure the VRF router ID address according to `<network_services_keys.name>[].vrfs[].bgp.router_id`.
+                  - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
+                  - `main_router_id` will configure the Loopback0 IP address.
+                  - An IPv4 address will be used directly as the source address.
+                  Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
+              version:
+                type: int
+                description: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
+                convert_types:
+                  - str
+                valid_values:
+                  - 1
+                  - 2
+                  - 3
+          fast_leave:
+            type: bool
+            description: Enable IGMP snooping fast-leave feature.
       igmp_snooping_enabled:
         documentation_options:
           table: network-services-multicast-settings
         type: bool
         description: Enable or disable IGMP snooping (Enabled by default on EOS).
+        deprecation:
+          warning: true
+          removed: false
+          remove_in_version: 7.0.0
+          new_key: igmp_snooping.enabled
       igmp_snooping_querier:
         documentation_options:
           table: network-services-multicast-settings
         type: dict
+        deprecation:
+          warning: true
+          removed: false
+          remove_in_version: 7.0.0
+          new_key: igmp_snooping.querier
         keys:
           enabled:
             type: bool
@@ -237,7 +282,7 @@ $defs:
               - 'diagnostic_loopback' will configure the VRF Diagnostic Loopback address.
               - `main_router_id` will configure the Loopback0 IP address.
               - An IPv4 address will be used directly as the source address.
-              Overrides `<network_services_key>[].igmp_snooping_querier.source_address`.
+              Overrides `<network_services_key>[].igmp_snooping.querier.source_address`.
           version:
             type: int
             description: IGMP Version (By default EOS uses IGMP version 2 for IGMP querier).
@@ -247,9 +292,6 @@ $defs:
               - 1
               - 2
               - 3
-          fast_leave:
-            type: bool
-            description: Enable IGMP snooping fast-leave feature.
       vxlan:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_igmp_snooping.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_igmp_snooping.py
@@ -86,9 +86,17 @@ class IpIgmpSnoopingMixin(Protocol):
             igmp_snooping_querier_enabled = True
 
         else:
-            igmp_snooping_enabled = vlan.igmp_snooping_enabled
+            # vlan.igmp_snooping.enabled takes precedence over deprecated key vlan.igmp_snooping_enabled.
+            igmp_snooping_enabled = default(vlan.igmp_snooping.enabled, vlan.igmp_snooping_enabled)
             if self.shared_utils.network_services_l3 and self.shared_utils.uplink_type in ["p2p", "p2p-vrfs"]:
-                igmp_snooping_querier_enabled = default(vlan.igmp_snooping_querier.enabled, tenant.igmp_snooping_querier.enabled)
+                # vlan.igmp_snooping.querier.enabled takes precedence over deprecated key vlan.igmp_snooping_querier.enabled.
+                # tenant.igmp_snooping.querier.enabled takes precedence over deprecated key tenant.igmp_snooping_querier.enabled.
+                igmp_snooping_querier_enabled = default(
+                    vlan.igmp_snooping.querier.enabled,
+                    vlan.igmp_snooping_querier.enabled,
+                    tenant.igmp_snooping.querier.enabled,
+                    tenant.igmp_snooping_querier.enabled,
+                )
 
         vlan_item = EosCliConfigGen.IpIgmpSnooping.VlansItem()
         if igmp_snooping_enabled is not None:
@@ -104,16 +112,27 @@ class IpIgmpSnoopingMixin(Protocol):
                     vlan = cast("EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.SvisItem", vlan)
                     vlan_item.querier.address = self._get_svi_igmp_querier_source_address(vlan, tenant, vrf)
 
-                vlan_item.querier.version = default(vlan.igmp_snooping_querier.version, tenant.igmp_snooping_querier.version)
+                # vlan.igmp_snooping.querier.version takes precedence over deprecated key vlan.igmp_snooping_querier.version.
+                # tenant.igmp_snooping.querier.version takes precedence over deprecated key tenant.igmp_snooping_querier.version.
+                vlan_item.querier.version = default(
+                    vlan.igmp_snooping.querier.version,
+                    vlan.igmp_snooping_querier.version,
+                    tenant.igmp_snooping.querier.version,
+                    tenant.igmp_snooping_querier.version,
+                )
 
         # When evpn_l2_multicast is enabled, can use deprecated evpn_l2_multicast.fast_leave for backward compatibility.
-        # TODO: 7.0.0 - Remove support for evpn_l2_multicast.fast_leave and clean up this logic.
+        # TODO: 7.0.0 - Remove support for evpn_l2_multicast.fast_leave and igmp_snooping_querier.fast_leave and clean up this logic.
         if evpn_l2_multicast_enabled:
-            # tenant.igmp.fast_leave takes precedence over deprecated key tenant.evpn_l2_multicast.fast_leave if both are set.
-            fast_leave = default(vlan.igmp_snooping_querier.fast_leave, tenant.igmp.fast_leave, tenant.evpn_l2_multicast.fast_leave)
+            # vlan.igmp_snooping.fast_leave takes precedence over deprecated key vlan.igmp_snooping_querier.fast_leave.
+            # tenant.igmp_snooping.fast_leave takes precedence over deprecated key tenant.evpn_l2_multicast.fast_leave if both are set.
+            fast_leave = default(
+                vlan.igmp_snooping.fast_leave, vlan.igmp_snooping_querier.fast_leave, tenant.igmp_snooping.fast_leave, tenant.evpn_l2_multicast.fast_leave
+            )
         else:
             # Set fast_leave regardless of evpn_l2_multicast_enabled state.
-            fast_leave = default(vlan.igmp_snooping_querier.fast_leave, tenant.igmp.fast_leave)
+            # vlan.igmp_snooping.fast_leave takes precedence over deprecated key vlan.igmp_snooping_querier.fast_leave.
+            fast_leave = default(vlan.igmp_snooping.fast_leave, vlan.igmp_snooping_querier.fast_leave, tenant.igmp_snooping.fast_leave)
 
         if fast_leave is not None:
             vlan_item.fast_leave = fast_leave
@@ -128,13 +147,20 @@ class IpIgmpSnoopingMixin(Protocol):
         tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
     ) -> str:
         """Return the IGMP snooping querier source address for an L2VLAN."""
-        source_address_key = default(l2vlan.igmp_snooping_querier.source_address, tenant.igmp_snooping_querier.source_address)
+        # l2vlan.igmp_snooping.querier.source_address takes precedence over deprecated key l2vlan.igmp_snooping_querier.source_address.
+        # tenant.igmp_snooping.querier.source_address takes precedence over deprecated key tenant.igmp_snooping_querier.source_address.
+        source_address_key = default(
+            l2vlan.igmp_snooping.querier.source_address,
+            l2vlan.igmp_snooping_querier.source_address,
+            tenant.igmp_snooping.querier.source_address,
+            tenant.igmp_snooping_querier.source_address,
+        )
 
         source_address = self.shared_utils.router_id if source_address_key in {"main_router_id", "diagnostic_loopback", "vrf_router_id"} else source_address_key
         msg = (
             f"Invalid IGMP snooping querier source address for VLAN '{l2vlan.name}' "
             f"in Tenant '{tenant.name}'. The value '{source_address}' resolved from "
-            f"'igmp_snooping_querier.source_address: {source_address_key}' "
+            f"'igmp_snooping.querier.source_address: {source_address_key}' "
             "is not a valid IPv4 address."
         )
         if source_address is not None:
@@ -153,7 +179,14 @@ class IpIgmpSnoopingMixin(Protocol):
         vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
     ) -> str:
         """Return the IGMP snooping querier source address for an SVI."""
-        source_address_key = default(svi.igmp_snooping_querier.source_address, tenant.igmp_snooping_querier.source_address)
+        # svi.igmp_snooping.querier.source_address takes precedence over deprecated key svi.igmp_snooping_querier.source_address.
+        # tenant.igmp_snooping.querier.source_address takes precedence over deprecated key tenant.igmp_snooping_querier.source_address.
+        source_address_key = default(
+            svi.igmp_snooping.querier.source_address,
+            svi.igmp_snooping_querier.source_address,
+            tenant.igmp_snooping.querier.source_address,
+            tenant.igmp_snooping_querier.source_address,
+        )
 
         match source_address_key:
             case "main_router_id":
@@ -169,7 +202,7 @@ class IpIgmpSnoopingMixin(Protocol):
                     msg = (
                         f"Invalid configuration on VRF '{vrf.name}' in Tenant '{tenant.name}'. 'vtep_diagnostic.loopback' along with either "
                         "'vtep_diagnostic.loopback_ip_pools' or 'vtep_diagnostic.loopback_ip_range' must be defined "
-                        "when 'igmp_snooping_querier.source_address' is set to 'diagnostic_loopback' on the VRF."
+                        "when 'igmp_snooping.querier.source_address' is set to 'diagnostic_loopback' on the VRF."
                     )
                     raise AristaAvdInvalidInputsError(msg) from None
             case _:
@@ -179,7 +212,7 @@ class IpIgmpSnoopingMixin(Protocol):
             f"Invalid IGMP snooping querier source address for VLAN '{svi.name}' "
             f"in VRF '{vrf.name}' in Tenant '{tenant.name}'. "
             f"The value '{source_address}' resolved from "
-            f"'igmp_snooping_querier.source_address: {source_address_key}' is not a valid IPv4 address."
+            f"'igmp_snooping.querier.source_address: {source_address_key}' is not a valid IPv4 address."
         )
 
         if source_address is not None:


### PR DESCRIPTION
## Change Summary

Adding a separate section for igmp_snooping in network_services schema

## Related Issue(s)

Fixes #6664 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Deprecating `igmp_snooping_enabled`, `igmp_snooping_querier` for l2vlans , svis and tenant
- Adding new key `igmp_snooping` with nested keys `enabled`, `querier` and `fast_leave`
- Updating code to support both new and old keys
- Adding test for both new and deprecated keys

## How to test
Molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
