### PR TITLE
Refactor(eos_designs): Adding structured_config property to StructuredConfigUtils class

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/__init__.py
@@ -110,7 +110,7 @@ def get_structured_config(
     custom_structured_configs = StructCfgs.new_from_ansible_list_merge_strategy(inputs.custom_structured_configuration_list_merge)
 
     # Create a single shared structured config utils instance for all structured config classes.
-    structured_config_utils = StructuredConfigUtils()
+    structured_config_utils = StructuredConfigUtils(structured_config=structured_config)
 
     for cls in AVD_STRUCTURED_CONFIG_CLASSES:
         eos_designs_module = cls(

--- a/python-avd/pyavd/_eos_designs/structured_config/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/__init__.py
@@ -110,7 +110,7 @@ def get_structured_config(
     custom_structured_configs = StructCfgs.new_from_ansible_list_merge_strategy(inputs.custom_structured_configuration_list_merge)
 
     # Create a single shared structured config utils instance for all structured config classes.
-    structured_config_utils = StructuredConfigUtils(structured_config=structured_config)
+    structured_config_utils = StructuredConfigUtils(structured_config=structured_config, inputs=inputs, shared_utils=shared_utils)
 
     for cls in AVD_STRUCTURED_CONFIG_CLASSES:
         eos_designs_module = cls(

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -25,8 +25,7 @@ class StructuredConfigUtils:
     """
 
     def __init__(self, structured_config: EosCliConfigGen) -> None:
-        """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance."""
-        super().__init__()
+        """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance and structured config instance.""
         self.structured_config = structured_config
         """The shared structured config instance to write config into."""
         self.parent_interfaces_tracker = ParentInterfacesTracker()

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 
 
-class StructuredConfigUtils():
+class StructuredConfigUtils:
     """
     Utility class for structured config generation.
 

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pyavd._eos_designs.structured_config.parent_interfaces import ParentInterfacesTracker
+from pyavd._utils.run_once import RunOnceMethodStateHelper
 
 if TYPE_CHECKING:
     from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+    from pyavd._eos_designs.schema import EosDesigns
+    from pyavd._eos_designs.shared_utils import SharedUtilsProtocol
 
 
 class StructuredConfigUtils(RunOnceMethodStateHelper):
@@ -24,9 +27,17 @@ class StructuredConfigUtils(RunOnceMethodStateHelper):
     This class holds shared utilities and trackers used across all structured config modules.
     """
 
-    def __init__(self, structured_config: EosCliConfigGen) -> None:
+    def __init__(
+        self,
+        structured_config: EosCliConfigGen,
+        inputs: EosDesigns,
+        shared_utils: SharedUtilsProtocol,
+    ) -> None:
         """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance and structured config instance."""
+        super().__init__()
         self.structured_config = structured_config
+        self.inputs = inputs
+        self.shared_utils = shared_utils
         """The shared structured config instance to write config into."""
         self.parent_interfaces_tracker = ParentInterfacesTracker()
         """Tracker for parent interfaces that need to be created for subinterfaces."""

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -25,7 +25,7 @@ class StructuredConfigUtils:
     """
 
     def __init__(self, structured_config: EosCliConfigGen) -> None:
-        """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance and structured config instance.""
+        """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance and structured config instance."""
         self.structured_config = structured_config
         """The shared structured config instance to write config into."""
         self.parent_interfaces_tracker = ParentInterfacesTracker()

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 
 
-class StructuredConfigUtils:
+class StructuredConfigUtils(RunOnceMethodStateHelper):
     """
     Utility class for structured config generation.
 

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_utils.py
@@ -9,18 +9,26 @@ This module provides utility classes for structured config generation.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pyavd._eos_designs.structured_config.parent_interfaces import ParentInterfacesTracker
 
+if TYPE_CHECKING:
+    from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 
-class StructuredConfigUtils:
+
+class StructuredConfigUtils():
     """
     Utility class for structured config generation.
 
     This class holds shared utilities and trackers used across all structured config modules.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, structured_config: EosCliConfigGen) -> None:
         """Initialize the StructuredConfigUtils with a ParentInterfacesTracker instance."""
+        super().__init__()
+        self.structured_config = structured_config
+        """The shared structured config instance to write config into."""
         self.parent_interfaces_tracker = ParentInterfacesTracker()
         """Tracker for parent interfaces that need to be created for subinterfaces."""
 


### PR DESCRIPTION
## Change Summary

Adding structured_config property to StructuredConfigUtils class to create structured config instance in order to write config into

## Related Issue(s)

Fixes 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes


## How to test


## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
