### PR TITLE
Doc: Remove p2p_uplinks_mtu override from all examples and how-to guides

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -1487,7 +1487,7 @@ interface Port-Channel53
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | Vlan10 | Inband Management | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -1509,7 +1509,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.4/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -1487,7 +1487,7 @@ interface Port-Channel53
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | Vlan10 | Inband Management | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -1509,7 +1509,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.5/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
@@ -58,9 +58,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management0 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management0 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
@@ -58,9 +58,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management0 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management0 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -2594,7 +2594,7 @@ interface Port-Channel983
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | Vlan10 | Inband Management | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -2616,7 +2616,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.10/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -2594,7 +2594,7 @@ interface Port-Channel983
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
 | Vlan10 | Inband Management | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -2616,7 +2616,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.11/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
@@ -59,9 +59,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,7 +343,7 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet52/1 | P2P_WAN_Ethernet1/1 | - | 10.0.0.3/31 | default | 1500 | False | - | - |
+| Ethernet52/1 | P2P_WAN_Ethernet1/1 | - | 10.0.0.3/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -372,7 +372,7 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_WAN_Ethernet1/1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.0.0.3/31
    ip ospf network point-to-point
@@ -481,8 +481,8 @@ interface Loopback0
 | Vlan310 | IDF3-Data | default | - | False |
 | Vlan320 | IDF3-Voice | default | - | False |
 | Vlan330 | IDF3-Guest | default | - | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -575,7 +575,7 @@ interface Vlan330
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.1.1.0/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
@@ -583,7 +583,7 @@ interface Vlan4093
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
@@ -56,9 +56,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,7 +343,7 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet52/1 | P2P_WAN_Ethernet1/1 | - | 10.0.0.5/31 | default | 1500 | False | - | - |
+| Ethernet52/1 | P2P_WAN_Ethernet1/1 | - | 10.0.0.5/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -372,7 +372,7 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_WAN_Ethernet1/1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.0.0.5/31
    ip ospf network point-to-point
@@ -481,8 +481,8 @@ interface Loopback0
 | Vlan310 | IDF3-Data | default | - | False |
 | Vlan320 | IDF3-Voice | default | - | False |
 | Vlan330 | IDF3-Guest | default | - | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -575,7 +575,7 @@ interface Vlan330
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.1.1.1/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
@@ -583,7 +583,7 @@ interface Vlan4093
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 ```

--- a/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
@@ -126,9 +126,6 @@ l2leaf:
           mgmt_ip: 172.16.100.110/24
           uplink_switch_interfaces: [Ethernet98/1, Ethernet98/1]
 
-#### Override for vEOS/cEOS Lab Caveats ####
-p2p_uplinks_mtu: 1500
-
 # Underlay Routing Protocol
 underlay_routing_protocol: ospf
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
@@ -1056,7 +1056,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.4/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
@@ -1056,7 +1056,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.5/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
@@ -2060,7 +2060,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.10/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
@@ -2060,7 +2060,7 @@ interface Vlan10
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.11/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
@@ -123,7 +123,7 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_WAN_Ethernet1/1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.0.0.3/31
    ip ospf network point-to-point
@@ -215,7 +215,7 @@ interface Vlan330
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.1.1.0/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
@@ -223,7 +223,7 @@ interface Vlan4093
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
@@ -123,7 +123,7 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_WAN_Ethernet1/1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.0.0.5/31
    ip ospf network point-to-point
@@ -215,7 +215,7 @@ interface Vlan330
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.1.1.1/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
@@ -223,7 +223,7 @@ interface Vlan4093
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -1789,7 +1789,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.4/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan10
   description: Inband Management

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -1789,7 +1789,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.5/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan10
   description: Inband Management

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -3488,7 +3488,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.10/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan10
   description: Inband Management

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -3488,7 +3488,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.11/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan10
   description: Inband Management

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -70,7 +70,7 @@ ethernet_interfaces:
 - name: Ethernet52/1
   description: P2P_WAN_Ethernet1/1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.0.0.3/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
@@ -213,12 +213,12 @@ vlan_interfaces:
   ip_address: 10.1.1.0/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.0/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan110
   description: IDF1-Data

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -70,7 +70,7 @@ ethernet_interfaces:
 - name: Ethernet52/1
   description: P2P_WAN_Ethernet1/1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.0.0.5/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
@@ -213,12 +213,12 @@ vlan_interfaces:
   ip_address: 10.1.1.1/31
   ospf_network_point_to_point: true
   ospf_area: 0.0.0.0
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.1/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan110
   description: IDF1-Data

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,8 +265,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 10.255.255.1/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 10.255.255.3/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 10.255.255.1/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 10.255.255.3/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -275,14 +275,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -408,10 +408,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -457,27 +457,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,8 +265,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 10.255.255.5/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 10.255.255.7/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 10.255.255.5/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 10.255.255.7/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -275,14 +275,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -408,10 +408,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -457,27 +457,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,9 +265,9 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 10.255.255.9/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 10.255.255.11/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_dc2-leaf2a_Ethernet6 | - | 172.16.100.0/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 10.255.255.9/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 10.255.255.11/31 | default | 9214 | False | - | - |
+| Ethernet6 | P2P_dc2-leaf2a_Ethernet6 | - | 172.16.100.0/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -276,14 +276,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.9/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.11/31
 !
@@ -305,7 +305,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc2-leaf2a_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.0/31
 !
@@ -416,10 +416,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -465,27 +465,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.68/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,9 +265,9 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 10.255.255.13/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 10.255.255.15/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_dc2-leaf2b_Ethernet6 | - | 172.16.100.2/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 10.255.255.13/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 10.255.255.15/31 | default | 9214 | False | - | - |
+| Ethernet6 | P2P_dc2-leaf2b_Ethernet6 | - | 172.16.100.2/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -276,14 +276,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.13/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.15/31
 !
@@ -305,7 +305,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc2-leaf2b_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.2/31
 !
@@ -416,10 +416,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -465,27 +465,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.69/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -155,10 +155,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 10.255.255.0/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 10.255.255.4/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 10.255.255.8/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 10.255.255.12/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 10.255.255.0/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 10.255.255.4/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 10.255.255.8/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 10.255.255.12/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -167,28 +167,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.8/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.12/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -155,10 +155,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 10.255.255.2/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 10.255.255.6/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 10.255.255.10/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 10.255.255.14/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 10.255.255.2/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 10.255.255.6/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 10.255.255.10/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 10.255.255.14/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -167,28 +167,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.10/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.14/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,8 +265,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-spine1_Ethernet1 | - | 10.255.255.65/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-spine2_Ethernet1 | - | 10.255.255.67/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-spine1_Ethernet1 | - | 10.255.255.65/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-spine2_Ethernet1 | - | 10.255.255.67/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -275,14 +275,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.65/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.67/31
 !
@@ -408,10 +408,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -457,27 +457,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.64/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,8 +265,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-spine1_Ethernet2 | - | 10.255.255.69/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-spine2_Ethernet2 | - | 10.255.255.71/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-spine1_Ethernet2 | - | 10.255.255.69/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-spine2_Ethernet2 | - | 10.255.255.71/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -275,14 +275,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.69/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.71/31
 !
@@ -408,10 +408,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -457,27 +457,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.65/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,9 +265,9 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-spine1_Ethernet3 | - | 10.255.255.73/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-spine2_Ethernet3 | - | 10.255.255.75/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_dc1-leaf2a_Ethernet6 | - | 172.16.100.1/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-spine1_Ethernet3 | - | 10.255.255.73/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-spine2_Ethernet3 | - | 10.255.255.75/31 | default | 9214 | False | - | - |
+| Ethernet6 | P2P_dc1-leaf2a_Ethernet6 | - | 172.16.100.1/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -276,14 +276,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.73/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.75/31
 !
@@ -305,7 +305,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc1-leaf2a_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.1/31
 !
@@ -416,10 +416,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -465,27 +465,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.68/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -61,9 +61,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -265,9 +265,9 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-spine1_Ethernet4 | - | 10.255.255.77/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-spine2_Ethernet4 | - | 10.255.255.79/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_dc1-leaf2b_Ethernet6 | - | 172.16.100.3/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-spine1_Ethernet4 | - | 10.255.255.77/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-spine2_Ethernet4 | - | 10.255.255.79/31 | default | 9214 | False | - | - |
+| Ethernet6 | P2P_dc1-leaf2b_Ethernet6 | - | 172.16.100.3/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -276,14 +276,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.77/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.79/31
 !
@@ -305,7 +305,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc1-leaf2b_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.3/31
 !
@@ -416,10 +416,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -465,27 +465,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.69/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2c.md
@@ -45,9 +45,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine1.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -155,10 +155,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-leaf1a_Ethernet1 | - | 10.255.255.64/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-leaf1b_Ethernet1 | - | 10.255.255.68/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc2-leaf2a_Ethernet1 | - | 10.255.255.72/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc2-leaf2b_Ethernet1 | - | 10.255.255.76/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-leaf1a_Ethernet1 | - | 10.255.255.64/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-leaf1b_Ethernet1 | - | 10.255.255.68/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc2-leaf2a_Ethernet1 | - | 10.255.255.72/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc2-leaf2b_Ethernet1 | - | 10.255.255.76/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -167,28 +167,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.64/31
 !
 interface Ethernet2
    description P2P_dc2-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.68/31
 !
 interface Ethernet3
    description P2P_dc2-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.72/31
 !
 interface Ethernet4
    description P2P_dc2-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.76/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-spine2.md
@@ -46,9 +46,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -155,10 +155,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc2-leaf1a_Ethernet2 | - | 10.255.255.66/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc2-leaf1b_Ethernet2 | - | 10.255.255.70/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc2-leaf2a_Ethernet2 | - | 10.255.255.74/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc2-leaf2b_Ethernet2 | - | 10.255.255.78/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc2-leaf1a_Ethernet2 | - | 10.255.255.66/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc2-leaf1b_Ethernet2 | - | 10.255.255.70/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc2-leaf2a_Ethernet2 | - | 10.255.255.74/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc2-leaf2b_Ethernet2 | - | 10.255.255.78/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -167,28 +167,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.66/31
 !
 interface Ethernet2
    description P2P_dc2-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.70/31
 !
 interface Ethernet3
    description P2P_dc2-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.74/31
 !
 interface Ethernet4
    description P2P_dc2-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.78/31
 ```

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
@@ -57,11 +57,6 @@ bgp_peer_groups:
   mlag_ipv4_underlay_peer:
     password: 4b21pAdCvWeAqpcKDFMdWw==
 
-# P2P interfaces MTU, includes VLANs 4093 and 4094 that are over peer-link
-# If you're running vEOS-lab or cEOS, you should use MTU of 1500 instead as shown in the following line
-# p2p_uplinks_mtu: 1500
-p2p_uplinks_mtu: 1500
-
 # Define default interfaces
 default_interfaces:
   - types: [spine]

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -178,27 +178,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -178,27 +178,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.9/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.11/31
 !
@@ -121,7 +121,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc2-leaf2a_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.0/31
 !
@@ -185,27 +185,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.68/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.13/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.15/31
 !
@@ -121,7 +121,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc2-leaf2b_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.2/31
 !
@@ -185,27 +185,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.69/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -27,28 +27,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.8/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.12/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -27,28 +27,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.10/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.14/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.65/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.67/31
 !
@@ -178,27 +178,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.64/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.69/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.71/31
 !
@@ -178,27 +178,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.65/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.73/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.75/31
 !
@@ -121,7 +121,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc1-leaf2a_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.1/31
 !
@@ -185,27 +185,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.68/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -92,14 +92,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc2-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.77/31
 !
 interface Ethernet2
    description P2P_dc2-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.79/31
 !
@@ -121,7 +121,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_dc1-leaf2b_Ethernet6
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 172.16.100.3/31
 !
@@ -185,27 +185,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.129.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.129.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.129.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.129.69/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
@@ -27,28 +27,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.64/31
 !
 interface Ethernet2
    description P2P_dc2-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.68/31
 !
 interface Ethernet3
    description P2P_dc2-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.72/31
 !
 interface Ethernet4
    description P2P_dc2-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.76/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
@@ -27,28 +27,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.66/31
 !
 interface Ethernet2
    description P2P_dc2-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.70/31
 !
 interface Ethernet3
    description P2P_dc2-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.74/31
 !
 interface Ethernet4
    description P2P_dc2-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.78/31
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.1/31
   metadata:
     peer: dc1-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.3/31
   metadata:
     peer: dc1-spine2
@@ -397,12 +397,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -425,7 +425,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -451,7 +451,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.5/31
   metadata:
     peer: dc1-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.7/31
   metadata:
     peer: dc1-spine2
@@ -397,12 +397,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -425,7 +425,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -451,7 +451,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.9/31
   metadata:
     peer: dc1-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.11/31
   metadata:
     peer: dc1-spine2
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet6
   description: P2P_dc2-leaf2a_Ethernet6
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 172.16.100.0/31
   metadata:
     peer: dc2-leaf2a
@@ -473,12 +473,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.68/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -501,7 +501,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -527,7 +527,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.13/31
   metadata:
     peer: dc1-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.15/31
   metadata:
     peer: dc1-spine2
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet6
   description: P2P_dc2-leaf2b_Ethernet6
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 172.16.100.2/31
   metadata:
     peer: dc2-leaf2b
@@ -473,12 +473,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.69/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -501,7 +501,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -527,7 +527,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.0/31
   metadata:
     peer: dc1-leaf1a
@@ -18,7 +18,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.4/31
   metadata:
     peer: dc1-leaf1b
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.8/31
   metadata:
     peer: dc1-leaf2a
@@ -40,7 +40,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.12/31
   metadata:
     peer: dc1-leaf2b

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.2/31
   metadata:
     peer: dc1-leaf1a
@@ -18,7 +18,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.6/31
   metadata:
     peer: dc1-leaf1b
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.10/31
   metadata:
     peer: dc1-leaf2a
@@ -40,7 +40,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.14/31
   metadata:
     peer: dc1-leaf2b

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.65/31
   metadata:
     peer: dc2-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.67/31
   metadata:
     peer: dc2-spine2
@@ -397,12 +397,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.129.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.129.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -425,7 +425,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.129.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -451,7 +451,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.129.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.69/31
   metadata:
     peer: dc2-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.71/31
   metadata:
     peer: dc2-spine2
@@ -397,12 +397,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.129.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.129.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -425,7 +425,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.129.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -451,7 +451,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.129.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-spine1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.73/31
   metadata:
     peer: dc2-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-spine2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.75/31
   metadata:
     peer: dc2-spine2
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet6
   description: P2P_dc1-leaf2a_Ethernet6
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 172.16.100.1/31
   metadata:
     peer: dc1-leaf2a
@@ -473,12 +473,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.129.100/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.129.68/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -501,7 +501,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.129.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -527,7 +527,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.129.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -27,7 +27,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-spine1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.77/31
   metadata:
     peer: dc2-spine1
@@ -38,7 +38,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-spine2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.79/31
   metadata:
     peer: dc2-spine2
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet6
   description: P2P_dc1-leaf2b_Ethernet6
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 172.16.100.3/31
   metadata:
     peer: dc1-leaf2b
@@ -473,12 +473,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.129.101/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.129.69/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -501,7 +501,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.129.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -527,7 +527,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.129.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.64/31
   metadata:
     peer: dc2-leaf1a
@@ -18,7 +18,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.68/31
   metadata:
     peer: dc2-leaf1b
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc2-leaf2a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.72/31
   metadata:
     peer: dc2-leaf2a
@@ -40,7 +40,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc2-leaf2b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.76/31
   metadata:
     peer: dc2-leaf2b

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc2-leaf1a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.66/31
   metadata:
     peer: dc2-leaf1a
@@ -18,7 +18,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc2-leaf1b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.70/31
   metadata:
     peer: dc2-leaf1b
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc2-leaf2a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.74/31
   metadata:
     peer: dc2-leaf2a
@@ -40,7 +40,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc2-leaf2b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.78/31
   metadata:
     peer: dc2-leaf2b

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/README.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/README.md
@@ -304,14 +304,11 @@ local_users: # (2)!
 bgp_peer_groups: # (3)!
   mpls_overlay_peers:
     password: Q4fqtbqcZ7oQuKfuWtNGRQ==
-
-p2p_uplinks_mtu: 1500 # (4)!
 ```
 
 1. The name of the fabric for internal AVD use. This name *must* match the name of an Ansible Group (and therefore a corresponding group_vars file) covering all network devices.
 2. Local users/passwords and their privilege levels. In this case, the `admin` user is set with no password and the `arista` user is set with the password `arista`.
 3. BGP peer groups and their passwords (all passwords are "arista").
-4. Point-to-point interface MTU, in this case, is set to 1500 since the example uses vEOS, but when using hardware, this should be set to 9214 instead.
 
 ## Setting device-specific configuration parameters
 
@@ -418,7 +415,6 @@ core_interfaces:
 
   p2p_links_profiles:
     - name: core_profile # (2)!
-      mtu: 1500
       isis_metric: 50
       ip_pool: core_pool
       isis_circuit_type: level-2

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -173,10 +173,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_pe1_Ethernet1 | - | 10.255.3.1/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_pe2_Ethernet2 | - | 10.255.3.7/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_rr1_Ethernet3 | - | 10.255.3.11/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_p2_Ethernet4 | - | 10.255.3.8/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_pe1_Ethernet1 | - | 10.255.3.1/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_pe2_Ethernet2 | - | 10.255.3.7/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_rr1_Ethernet3 | - | 10.255.3.11/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_p2_Ethernet4 | - | 10.255.3.8/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -194,7 +194,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_pe1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.1/31
    mpls ldp igp sync
@@ -211,7 +211,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_pe2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.7/31
    mpls ldp igp sync
@@ -228,7 +228,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_rr1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.11/31
    mpls ldp igp sync
@@ -245,7 +245,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.8/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -173,10 +173,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_pe2_Ethernet1 | - | 10.255.3.5/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_pe1_Ethernet2 | - | 10.255.3.3/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_rr2_Ethernet3 | - | 10.255.3.17/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_p1_Ethernet4 | - | 10.255.3.9/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_pe2_Ethernet1 | - | 10.255.3.5/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_pe1_Ethernet2 | - | 10.255.3.3/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_rr2_Ethernet3 | - | 10.255.3.17/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_p1_Ethernet4 | - | 10.255.3.9/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -194,7 +194,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_pe2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.5/31
    mpls ldp igp sync
@@ -211,7 +211,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_pe1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.3/31
    mpls ldp igp sync
@@ -228,7 +228,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_rr2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.17/31
    mpls ldp igp sync
@@ -245,7 +245,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.9/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -173,9 +173,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_pe3_Ethernet1 | - | 10.255.3.23/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_rr1_Ethernet2 | - | 10.255.3.13/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_p4_Ethernet4 | - | 10.255.3.20/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_pe3_Ethernet1 | - | 10.255.3.23/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_rr1_Ethernet2 | - | 10.255.3.13/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_p4_Ethernet4 | - | 10.255.3.20/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -192,7 +192,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_pe3_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.23/31
    mpls ldp igp sync
@@ -209,7 +209,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_rr1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.13/31
    mpls ldp igp sync
@@ -226,7 +226,7 @@ interface Ethernet2
 interface Ethernet4
    description P2P_p4_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.20/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -173,9 +173,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet2 | P2P_rr2_Ethernet2 | - | 10.255.3.19/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_pe3_Ethernet3 | - | 10.255.3.25/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_p3_Ethernet4 | - | 10.255.3.21/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_rr2_Ethernet2 | - | 10.255.3.19/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_pe3_Ethernet3 | - | 10.255.3.25/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_p3_Ethernet4 | - | 10.255.3.21/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -192,7 +192,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet2
    description P2P_rr2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.19/31
    mpls ldp igp sync
@@ -209,7 +209,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_pe3_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.25/31
    mpls ldp igp sync
@@ -226,7 +226,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p3_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.21/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
@@ -48,9 +48,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -187,8 +187,8 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_p1_Ethernet1 | - | 10.255.3.0/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_p2_Ethernet2 | - | 10.255.3.2/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_p1_Ethernet1 | - | 10.255.3.0/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_p2_Ethernet2 | - | 10.255.3.2/31 | default | 9214 | False | - | - |
 | Ethernet3.10 | C1_L3_SERVICE | - | 10.0.1.1/29 | C1_VRF1 | - | False | - | - |
 | Ethernet3.20 | C2_L3_SERVICE | - | 10.1.1.1/29 | C2_VRF1 | - | False | - | - |
 
@@ -206,7 +206,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_p1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.0/31
    mpls ldp igp sync
@@ -223,7 +223,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_p2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.2/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -187,8 +187,8 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_p2_Ethernet1 | - | 10.255.3.4/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_p1_Ethernet2 | - | 10.255.3.6/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_p2_Ethernet1 | - | 10.255.3.4/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_p1_Ethernet2 | - | 10.255.3.6/31 | default | 9214 | False | - | - |
 | Ethernet4.10 | C1_L3_SERVICE | - | 10.0.1.2/29 | C1_VRF1 | - | False | - | - |
 | Ethernet4.20 | C2_L3_SERVICE | - | 10.1.1.2/29 | C2_VRF1 | - | False | - | - |
 
@@ -206,7 +206,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_p2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.4/31
    mpls ldp igp sync
@@ -223,7 +223,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_p1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.6/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -180,9 +180,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_p3_Ethernet1 | - | 10.255.3.22/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_p3_Ethernet1 | - | 10.255.3.22/31 | default | 9214 | False | - | - |
 | Ethernet2 | C1_L3_SERVICE | - | 10.0.1.9/30 | C1_VRF1 | - | False | - | - |
-| Ethernet3 | P2P_p4_Ethernet3 | - | 10.255.3.24/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_p4_Ethernet3 | - | 10.255.3.24/31 | default | 9214 | False | - | - |
 | Ethernet4 | C2_L3_SERVICE | - | 10.1.1.9/30 | C2_VRF1 | - | False | - | - |
 
 ##### ISIS
@@ -199,7 +199,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_p3_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.22/31
    mpls ldp igp sync
@@ -224,7 +224,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p4_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.24/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
@@ -55,9 +55,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -176,9 +176,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet2 | P2P_p3_Ethernet2 | - | 10.255.3.12/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_p1_Ethernet3 | - | 10.255.3.10/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_rr2_Ethernet4 | - | 10.255.3.14/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_p3_Ethernet2 | - | 10.255.3.12/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_p1_Ethernet3 | - | 10.255.3.10/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_rr2_Ethernet4 | - | 10.255.3.14/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -195,7 +195,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet2
    description P2P_p3_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.12/31
    mpls ldp igp sync
@@ -212,7 +212,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.10/31
    mpls ldp igp sync
@@ -229,7 +229,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_rr2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.14/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -176,9 +176,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet2 | P2P_p4_Ethernet2 | - | 10.255.3.18/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_p2_Ethernet3 | - | 10.255.3.16/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_rr1_Ethernet4 | - | 10.255.3.15/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_p4_Ethernet2 | - | 10.255.3.18/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_p2_Ethernet3 | - | 10.255.3.16/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_rr1_Ethernet4 | - | 10.255.3.15/31 | default | 9214 | False | - | - |
 
 ##### ISIS
 
@@ -195,7 +195,7 @@ vlan internal order ascending range 1006 1199
 interface Ethernet2
    description P2P_p4_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.18/31
    mpls ldp igp sync
@@ -212,7 +212,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.16/31
    mpls ldp igp sync
@@ -229,7 +229,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_rr1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.15/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/group_vars/WAN1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/group_vars/WAN1.yml
@@ -104,8 +104,6 @@ core_interfaces:
   p2p_links_profiles:
     - name: core_profile
       # speed: 100gfull
-      # On vEOS-lab, MTU values larger than 1500 can cause issues, in an actual production network this is normally a larger value
-      mtu: 1500
       isis_metric: 50
       ip_pool: core_pool
       isis_circuit_type: level-2

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet1
    description P2P_pe1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.1/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_pe2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.7/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_rr1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.11/31
    mpls ldp igp sync
@@ -81,7 +81,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.8/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet1
    description P2P_pe2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.5/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_pe1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.3/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_rr2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.17/31
    mpls ldp igp sync
@@ -81,7 +81,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.9/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet1
    description P2P_pe3_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.23/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_rr1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.13/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet2
 interface Ethernet4
    description P2P_p4_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.20/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet2
    description P2P_rr2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.19/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_pe3_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.25/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_p3_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.21/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
@@ -34,7 +34,7 @@ management security
 interface Ethernet1
    description P2P_p1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.0/31
    mpls ldp igp sync
@@ -51,7 +51,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_p2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.2/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
@@ -34,7 +34,7 @@ management security
 interface Ethernet1
    description P2P_p2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.4/31
    mpls ldp igp sync
@@ -51,7 +51,7 @@ interface Ethernet1
 interface Ethernet2
    description P2P_p1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.6/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
@@ -34,7 +34,7 @@ management security
 interface Ethernet1
    description P2P_p3_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.22/31
    mpls ldp igp sync
@@ -59,7 +59,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p4_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.24/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet2
    description P2P_p3_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.12/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.10/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_rr2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.14/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
@@ -30,7 +30,7 @@ management security
 interface Ethernet2
    description P2P_p4_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.18/31
    mpls ldp igp sync
@@ -47,7 +47,7 @@ interface Ethernet2
 interface Ethernet3
    description P2P_p2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.16/31
    mpls ldp igp sync
@@ -64,7 +64,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_rr1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.3.15/31
    mpls ldp igp sync

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_pe1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.1/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_pe2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.7/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_p2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.8/31
   isis_enable: CORE
   isis_metric: 50
@@ -85,7 +85,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_rr1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.11/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_pe1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.3/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_pe2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.5/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_p1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.9/31
   isis_enable: CORE
   isis_metric: 50
@@ -85,7 +85,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_rr2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.17/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_rr1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.13/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_p4_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.20/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_pe3_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.23/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_rr2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.19/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_p3_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.21/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_pe3_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.25/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_p1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.0/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_p2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.2/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_p2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.4/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_p1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.6/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_p3_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.22/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_p4_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.24/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_p1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.10/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_p3_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.12/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_rr2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.14/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
@@ -7,7 +7,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_rr1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.15/31
   isis_enable: CORE
   isis_metric: 50
@@ -33,7 +33,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_p2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.16/31
   isis_enable: CORE
   isis_metric: 50
@@ -59,7 +59,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_p4_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.3.18/31
   isis_enable: CORE
   isis_metric: 50

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -385,7 +385,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -400,7 +400,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -385,7 +385,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -400,7 +400,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -385,7 +385,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -400,7 +400,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.4/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -385,7 +385,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -400,7 +400,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.5/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -416,7 +416,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -431,7 +431,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -416,7 +416,7 @@ interface Port-Channel47
 
 | Interface | Description | VRF | MTU | Shutdown |
 | --------- | ----------- | --- | --- | -------- |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -431,7 +431,7 @@ interface Port-Channel47
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 ```

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -54,9 +54,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1.yml
@@ -4,8 +4,5 @@
 # OOB Management network default gateway
 mgmt_gateway: 172.16.100.1
 
-#### Override for vEOS/cEOS Lab Caveats ####
-p2p_uplinks_mtu: 1500
-
 management_eapi:
   enabled: true

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
@@ -94,7 +94,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
@@ -94,7 +94,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
@@ -94,7 +94,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.4/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
@@ -94,7 +94,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.5/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
@@ -120,7 +120,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.0/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
@@ -120,7 +120,7 @@ interface Management1
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 192.168.0.1/31
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -157,7 +157,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.0/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -157,7 +157,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.1/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -157,7 +157,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.4/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -157,7 +157,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.5/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -193,7 +193,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.0/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -193,7 +193,7 @@ vlan_interfaces:
   description: MLAG
   shutdown: false
   ip_address: 192.168.0.1/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 2001:db8:2::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 2001:db8:2:1::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 2001:db8:2::2/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 2001:db8:2:1::2/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -366,14 +366,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:1::2/64
 !
@@ -509,11 +509,11 @@ interface Loopback12
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
 | Vlan31 | VRF12_VLAN31 | VRF12 | - | False |
 | Vlan32 | VRF12_VLAN32 | VRF12 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -590,34 +590,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3::1/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 2001:db8:2::2/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 2001:db8:2:1::2/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 2001:db8:2::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 2001:db8:2:1::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::1/64 | - | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 2001:db8:2:2::2/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 2001:db8:2:3::2/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 2001:db8:2:2::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 2001:db8:2:3::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 2001:db8:2:2::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 2001:db8:2:3::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 2001:db8:2:2::2/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 2001:db8:2:3::2/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -366,14 +366,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:2::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:3::2/64
 !
@@ -509,11 +509,11 @@ interface Loopback12
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
 | Vlan31 | VRF12_VLAN31 | VRF12 | - | False |
 | Vlan32 | VRF12_VLAN32 | VRF12 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3::2/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -590,34 +590,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3::2/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf1c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 2001:db8:2:4::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 2001:db8:2:5::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 2001:db8:2:4::2/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 2001:db8:2:5::2/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -366,14 +366,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:4::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:5::2/64
 !
@@ -509,11 +509,11 @@ interface Loopback12
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
 | Vlan31 | VRF12_VLAN31 | VRF12 | - | False |
 | Vlan32 | VRF12_VLAN32 | VRF12 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -590,34 +590,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3:2::1/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 2001:db8:2:4::2/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 2001:db8:2:5::2/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 2001:db8:2:4::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 2001:db8:2:5::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::1/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::1/64 | - | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 2001:db8:2:6::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 2001:db8:2:7::2/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 2001:db8:2:6::2/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 2001:db8:2:7::2/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -366,14 +366,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:6::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:7::2/64
 !
@@ -509,11 +509,11 @@ interface Loopback12
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
 | Vlan31 | VRF12_VLAN31 | VRF12 | - | False |
 | Vlan32 | VRF12_VLAN32 | VRF12 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan3011 | MLAG_L3_VRF_VRF12 | VRF12 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 
@@ -590,34 +590,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3:2::2/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -354,10 +354,10 @@ vlan 4094
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 2001:db8:2:6::2/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 2001:db8:2:7::2/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 2001:db8:2:6::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 2001:db8:2:7::2/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -533,16 +533,16 @@ interface Loopback12
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | ----------- | ------------ |
-| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - |
-| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - |
-| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - |
-| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
-| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
-| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
-| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - |
-| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - | - |
+| Interface | VRF | IPv6 Addresses | IPv6 Virtual Addresses | Virtual Router Addresses | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | -------------- | ---------------------- | ------------------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Vlan21 | VRF11 | - | 2001:DB8:21::1/48 | - | - | - | - | - | - | - | - |
+| Vlan31 | VRF12 | - | 2001:DB8:31::1/48 | - | - | - | - | - | - | - | - |
+| Vlan32 | VRF12 | - | 2001:DB8:32::1/48 | - | - | - | - | - | - | - | - |
+| Vlan3009 | VRF10 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3010 | VRF11 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan3011 | VRF12 | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4093 | default | 2001:db8:4:2::2/64 | - | - | - | - | - | - | - | - | - |
+| Vlan4094 | default | 2001:db8:3:2::2/64 | - | - | - | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-leaf2c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -231,12 +231,12 @@ vlan internal order ascending range 1006 1199
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 2001:db8:2::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 2001:db8:2:2::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 2001:db8:2:4::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 2001:db8:2:6::1/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 2001:db8:2::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 2001:db8:2:2::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 2001:db8:2:4::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 2001:db8:2:6::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -231,12 +231,12 @@ vlan internal order ascending range 1006 1199
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 2001:db8:2::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 2001:db8:2:2::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 2001:db8:2:4::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 2001:db8:2:6::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 2001:db8:2::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 2001:db8:2:2::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 2001:db8:2:4::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 2001:db8:2:6::1/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -245,28 +245,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2::1/64
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:2::1/64
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:4::1/64
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:6::1/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -231,12 +231,12 @@ vlan internal order ascending range 1006 1199
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 2001:db8:2:1::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 2001:db8:2:3::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 2001:db8:2:5::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 2001:db8:2:7::1/64 | default | 1500 | False | - | - | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 2001:db8:2:1::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 2001:db8:2:3::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 2001:db8:2:5::1/64 | default | 9214 | False | - | - | - | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 2001:db8:2:7::1/64 | default | 9214 | False | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -245,28 +245,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:1::1/64
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:3::1/64
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:5::1/64
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:7::1/64
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/documentation/devices/dc1-spine2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -231,12 +231,12 @@ vlan internal order ascending range 1006 1199
 
 ##### IPv6
 
-| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | ----------- | ------------ |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 2001:db8:2:1::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 2001:db8:2:3::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 2001:db8:2:5::1/64 | default | 9214 | False | - | - | - | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 2001:db8:2:7::1/64 | default | 9214 | False | - | - | - | - | - |
+| Interface | Description | Channel Group | IPv6 Addresses | VRF | MTU | Shutdown | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache | IPv6 ACL In | IPv6 ACL Out |
+| --------- | ----------- | ------------- | -------------- | --- | --- | -------- | -------------- | --------------- | ---------------------- | -------------------- | -------- | ----------- | ------------ |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 2001:db8:2:1::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 2001:db8:2:3::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 2001:db8:2:5::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 2001:db8:2:7::1/64 | default | 9214 | False | - | - | - | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/group_vars/FABRIC/fabric_variables.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/group_vars/FABRIC/fabric_variables.yml
@@ -37,11 +37,6 @@ bgp_peer_groups:
     name: MLAG-IPv6-UNDERLAY-PEER
     password: GNtuK+/vTwZwSZiwj1FK/Q==
 
-# P2P interfaces MTU, includes VLANs 4093 and 4094 that are over peer-link
-# If you're running vEOS-lab or cEOS, you should use MTU of 1500 instead as shown in the following line
-# p2p_uplinks_mtu: 9214
-p2p_uplinks_mtu: 1500
-
 # Set default uplink, downlink, and MLAG interfaces based on node type
 default_interfaces:
   - types: [spine]

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf1a.cfg
@@ -110,14 +110,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:1::2/64
 !
@@ -217,34 +217,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4::1/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3::1/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf1b.cfg
@@ -110,14 +110,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:2::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:3::2/64
 !
@@ -217,34 +217,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4::2/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3::2/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf2a.cfg
@@ -110,14 +110,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:4::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:5::2/64
 !
@@ -217,34 +217,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4:2::1/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3:2::1/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-leaf2b.cfg
@@ -110,14 +110,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:6::2/64
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:7::2/64
 !
@@ -217,34 +217,34 @@ interface Vlan32
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan3011
    description MLAG_L3_VRF_VRF12
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF12
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ipv6 address 2001:db8:4:2::2/64
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ipv6 address 2001:db8:3:2::2/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-spine1.cfg
@@ -33,28 +33,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2::1/64
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:2::1/64
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:4::1/64
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:6::1/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/configs/dc1-spine2.cfg
@@ -33,28 +33,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:1::1/64
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:3::1/64
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:5::1/64
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ipv6 address 2001:db8:2:7::1/64
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf1a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2::2/64
   metadata:
@@ -49,7 +49,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:1::2/64
   metadata:
@@ -479,13 +479,13 @@ vlan_interfaces:
   shutdown: false
   ipv6_addresses:
   - 2001:db8:4::1/64
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ipv6_addresses:
   - 2001:db8:3::1/64
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -509,7 +509,7 @@ vlan_interfaces:
   vrf: VRF10
   ipv6_addresses:
   - 2001:db8:4::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -538,7 +538,7 @@ vlan_interfaces:
   vrf: VRF11
   ipv6_addresses:
   - 2001:db8:4::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -569,7 +569,7 @@ vlan_interfaces:
   vrf: VRF12
   ipv6_addresses:
   - 2001:db8:4::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf1b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:2::2/64
   metadata:
@@ -49,7 +49,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:3::2/64
   metadata:
@@ -479,13 +479,13 @@ vlan_interfaces:
   shutdown: false
   ipv6_addresses:
   - 2001:db8:4::2/64
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ipv6_addresses:
   - 2001:db8:3::2/64
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -509,7 +509,7 @@ vlan_interfaces:
   vrf: VRF10
   ipv6_addresses:
   - 2001:db8:4::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -538,7 +538,7 @@ vlan_interfaces:
   vrf: VRF11
   ipv6_addresses:
   - 2001:db8:4::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -569,7 +569,7 @@ vlan_interfaces:
   vrf: VRF12
   ipv6_addresses:
   - 2001:db8:4::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf2a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:4::2/64
   metadata:
@@ -49,7 +49,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:5::2/64
   metadata:
@@ -479,13 +479,13 @@ vlan_interfaces:
   shutdown: false
   ipv6_addresses:
   - 2001:db8:4:2::1/64
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ipv6_addresses:
   - 2001:db8:3:2::1/64
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -509,7 +509,7 @@ vlan_interfaces:
   vrf: VRF10
   ipv6_addresses:
   - 2001:db8:4:2::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -538,7 +538,7 @@ vlan_interfaces:
   vrf: VRF11
   ipv6_addresses:
   - 2001:db8:4:2::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -569,7 +569,7 @@ vlan_interfaces:
   vrf: VRF12
   ipv6_addresses:
   - 2001:db8:4:2::1/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-leaf2b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:6::2/64
   metadata:
@@ -49,7 +49,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:7::2/64
   metadata:
@@ -479,13 +479,13 @@ vlan_interfaces:
   shutdown: false
   ipv6_addresses:
   - 2001:db8:4:2::2/64
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ipv6_addresses:
   - 2001:db8:3:2::2/64
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -509,7 +509,7 @@ vlan_interfaces:
   vrf: VRF10
   ipv6_addresses:
   - 2001:db8:4:2::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -538,7 +538,7 @@ vlan_interfaces:
   vrf: VRF11
   ipv6_addresses:
   - 2001:db8:4:2::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -569,7 +569,7 @@ vlan_interfaces:
   vrf: VRF12
   ipv6_addresses:
   - 2001:db8:4:2::2/64
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-spine1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2::1/64
   metadata:
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:2::1/64
   metadata:
@@ -41,7 +41,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:4::1/64
   metadata:
@@ -53,7 +53,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:6::1/64
   metadata:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/intended/structured_configs/dc1-spine2.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:1::1/64
   metadata:
@@ -29,7 +29,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:3::1/64
   metadata:
@@ -41,7 +41,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:5::1/64
   metadata:
@@ -53,7 +53,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ipv6_addresses:
   - 2001:db8:2:7::1/64
   metadata:

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,8 +343,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 10.255.255.1/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 10.255.255.3/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet1 | - | 10.255.255.1/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet1 | - | 10.255.255.3/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -353,14 +353,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -486,10 +486,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -535,27 +535,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,8 +343,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 10.255.255.5/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 10.255.255.7/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet2 | - | 10.255.255.5/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet2 | - | 10.255.255.7/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -353,14 +353,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -486,10 +486,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -535,27 +535,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,8 +343,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 10.255.255.9/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 10.255.255.11/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet3 | - | 10.255.255.9/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet3 | - | 10.255.255.11/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -353,14 +353,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.9/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.11/31
 !
@@ -486,10 +486,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -535,27 +535,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.68/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -343,8 +343,8 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 10.255.255.13/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 10.255.255.15/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-spine1_Ethernet4 | - | 10.255.255.13/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-spine2_Ethernet4 | - | 10.255.255.15/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -353,14 +353,14 @@ vlan 4094
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.13/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.15/31
 !
@@ -486,10 +486,10 @@ interface Loopback11
 | Vlan12 | VRF10_VLAN12 | VRF10 | - | False |
 | Vlan21 | VRF11_VLAN21 | VRF11 | - | False |
 | Vlan22 | VRF11_VLAN22 | VRF11 | - | False |
-| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 1500 | False |
-| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 1500 | False |
-| Vlan4093 | MLAG_L3 | default | 1500 | False |
-| Vlan4094 | MLAG | default | 1500 | False |
+| Vlan3009 | MLAG_L3_VRF_VRF10 | VRF10 | 9214 | False |
+| Vlan3010 | MLAG_L3_VRF_VRF11 | VRF11 | 9214 | False |
+| Vlan4093 | MLAG_L3 | default | 9214 | False |
+| Vlan4094 | MLAG | default | 9214 | False |
 
 ##### IPv4
 
@@ -535,27 +535,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.69/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -66,9 +66,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2c.md
@@ -50,9 +50,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -233,10 +233,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 10.255.255.0/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 10.255.255.4/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 10.255.255.8/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 10.255.255.12/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet1 | - | 10.255.255.0/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet1 | - | 10.255.255.4/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet1 | - | 10.255.255.8/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet1 | - | 10.255.255.12/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -245,28 +245,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.8/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.12/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine1.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-spine2.md
@@ -51,9 +51,9 @@
 
 ##### IPv6
 
-| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA Disabled | ND RA RX Accept | ND Managed Config Flag | ND Other Config Flag | ND Cache |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ | -------------- | --------------- | ---------------------- | -------------------- | -------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - | - | - |
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway | ND RA RX Accept | ND RA Disabled | ND Managed Config Flag |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ | --------------- | -------------- | ---------------------- |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | - | - | - | - | - |
 
 #### Management Interfaces Device Configuration
 
@@ -233,10 +233,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Channel Group | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | --- | --- | -------- | ------ | ------- |
-| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 10.255.255.2/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 10.255.255.6/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 10.255.255.10/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 10.255.255.14/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_dc1-leaf1a_Ethernet2 | - | 10.255.255.2/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_dc1-leaf1b_Ethernet2 | - | 10.255.255.6/31 | default | 9214 | False | - | - |
+| Ethernet3 | P2P_dc1-leaf2a_Ethernet2 | - | 10.255.255.10/31 | default | 9214 | False | - | - |
+| Ethernet4 | P2P_dc1-leaf2b_Ethernet2 | - | 10.255.255.14/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -245,28 +245,28 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.10/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.14/31
 ```

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/FABRIC/fabric_variables.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/group_vars/FABRIC/fabric_variables.yml
@@ -35,11 +35,6 @@ bgp_peer_groups:
   mlag_ipv4_underlay_peer:
     password: 4b21pAdCvWeAqpcKDFMdWw==
 
-# P2P interfaces MTU, includes VLANs 4093 and 4094 that are over peer-link
-# If you're running vEOS-lab or cEOS, you should use MTU of 1500 instead as shown in the following line
-# p2p_uplinks_mtu: 9214
-p2p_uplinks_mtu: 1500
-
 # Set default uplink, downlink, and MLAG interfaces based on node type
 default_interfaces:
   - types: [spine]

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -98,14 +98,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -184,27 +184,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -98,14 +98,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -184,27 +184,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -98,14 +98,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.9/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.11/31
 !
@@ -184,27 +184,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.100/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.100/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.100/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.68/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -98,14 +98,14 @@ interface Port-Channel8
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.13/31
 !
 interface Ethernet2
    description P2P_dc1-spine2_Ethernet4
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.15/31
 !
@@ -184,27 +184,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.101/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.101/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.101/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.69/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -33,28 +33,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.8/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.12/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -33,28 +33,28 @@ management api http-commands
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !
 interface Ethernet3
    description P2P_dc1-leaf2a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.10/31
 !
 interface Ethernet4
    description P2P_dc1-leaf2b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.14/31
 !

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.1/31
   metadata:
     peer: dc1-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.3/31
   metadata:
     peer: dc1-spine2
@@ -424,12 +424,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -452,7 +452,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -478,7 +478,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.5/31
   metadata:
     peer: dc1-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.7/31
   metadata:
     peer: dc1-spine2
@@ -424,12 +424,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -452,7 +452,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -478,7 +478,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.9/31
   metadata:
     peer: dc1-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.11/31
   metadata:
     peer: dc1-spine2
@@ -424,12 +424,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.68/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -452,7 +452,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -478,7 +478,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.100/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.13/31
   metadata:
     peer: dc1-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-spine2_Ethernet4
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.15/31
   metadata:
     peer: dc1-spine2
@@ -424,12 +424,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.69/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -452,7 +452,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -478,7 +478,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.101/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.0/31
   metadata:
     peer: dc1-leaf1a
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.4/31
   metadata:
     peer: dc1-leaf1b
@@ -39,7 +39,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.8/31
   metadata:
     peer: dc1-leaf2a
@@ -50,7 +50,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.12/31
   metadata:
     peer: dc1-leaf2b

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.2/31
   metadata:
     peer: dc1-leaf1a
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.6/31
   metadata:
     peer: dc1-leaf1b
@@ -39,7 +39,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-leaf2a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.10/31
   metadata:
     peer: dc1-leaf2a
@@ -50,7 +50,7 @@ ethernet_interfaces:
 - name: Ethernet4
   description: P2P_dc1-leaf2b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.14/31
   metadata:
     peer: dc1-leaf2b

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/FABRIC/fabric_variables.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/FABRIC/fabric_variables.yml
@@ -36,11 +36,6 @@ bgp_peer_groups:
   mlag_ipv4_underlay_peer:
     password: 4b21pAdCvWeAqpcKDFMdWw==
 
-# P2P interfaces MTU, includes VLANs 4093 and 4094 that are over peer-link
-# If you're running vEOS-lab or cEOS, you should use MTU of 1500 instead as shown in the following line
-# p2p_uplinks_mtu: 9214
-p2p_uplinks_mtu: 1500
-
 # Set default uplink, downlink, and MLAG interfaces based on node type
 default_interfaces:
   - types: [spine]

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTFT/fabric.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTFT/fabric.yml
@@ -7,6 +7,3 @@ fabric_name: FABRIC # (1)!
 # Define underlay and overlay routing protocols
 underlay_routing_protocol: ebgp # (2)!
 overlay_routing_protocol: ebgp # (3)!
-
-# P2P uplinks MTU - use 1500 for vEOS-lab/cEOS, 9214 for production
-p2p_uplinks_mtu: 1500 # (4)!

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-leaf1a.cfg
@@ -82,7 +82,7 @@ interface Port-Channel11
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
@@ -164,27 +164,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.96/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-leaf1b.cfg
@@ -82,7 +82,7 @@ interface Port-Channel11
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -156,27 +156,27 @@ interface Vlan22
 interface Vlan3009
    description MLAG_L3_VRF_VRF10
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF10
    ip address 10.255.1.97/31
 !
 interface Vlan3010
    description MLAG_L3_VRF_VRF11
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF11
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-spine1.cfg
@@ -26,21 +26,21 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_dc1-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet3
    description P2P_dc1-svc-leaf1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.82/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-svc-leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/dc1-svc-leaf1.cfg
@@ -49,7 +49,7 @@ vrf instance VRF11
 interface Ethernet1
    description P2P_dc1-spine1_Ethernet3
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.83/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-leaf1a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-leaf1a.cfg
@@ -43,14 +43,14 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_htft-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_htft-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -83,13 +83,13 @@ interface Management1
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-leaf1b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-leaf1b.cfg
@@ -43,14 +43,14 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_htft-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_htft-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -83,13 +83,13 @@ interface Management1
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-spine1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-spine1.cfg
@@ -26,14 +26,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_htft-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_htft-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-spine2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htft-spine2.cfg
@@ -26,14 +26,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_htft-leaf1a_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_htft-leaf1b_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-leaf1.cfg
@@ -43,14 +43,14 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_htipa-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_htipa-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !
@@ -83,13 +83,13 @@ interface Management1
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.3.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.3.64/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-leaf2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-leaf2.cfg
@@ -43,14 +43,14 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_htipa-spine1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.5/31
 !
 interface Ethernet2
    description P2P_htipa-spine2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.7/31
 !
@@ -83,13 +83,13 @@ interface Management1
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.3.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.3.65/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-spine1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-spine1.cfg
@@ -26,14 +26,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_htipa-leaf1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_htipa-leaf2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-spine2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htipa-spine2.cfg
@@ -26,14 +26,14 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_htipa-leaf1_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.2/31
 !
 interface Ethernet2
    description P2P_htipa-leaf2_Ethernet2
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.6/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htns-l3-leaf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htns-l3-leaf1.cfg
@@ -134,27 +134,27 @@ interface Vlan200
 interface Vlan3099
    description MLAG_L3_VRF_VRF_PRODUCTION
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF_PRODUCTION
    ip address 10.255.1.96/31
 !
 interface Vlan3199
    description MLAG_L3_VRF_VRF_DEVELOPMENT
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF_DEVELOPMENT
    ip address 10.255.1.96/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.96/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.64/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htns-l3-leaf2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htns-l3-leaf2.cfg
@@ -84,20 +84,20 @@ interface Vlan200
 interface Vlan3199
    description MLAG_L3_VRF_VRF_DEVELOPMENT
    no shutdown
-   mtu 1500
+   mtu 9214
    vrf VRF_DEVELOPMENT
    ip address 10.255.1.97/31
 !
 interface Vlan4093
    description MLAG_L3
    no shutdown
-   mtu 1500
+   mtu 9214
    ip address 10.255.1.97/31
 !
 interface Vlan4094
    description MLAG
    no shutdown
-   mtu 1500
+   mtu 9214
    no autostate
    ip address 10.255.1.65/31
 !

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-leaf1a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.1/31
   metadata:
     peer: dc1-spine1
@@ -390,12 +390,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -418,7 +418,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -444,7 +444,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-leaf1b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.3/31
   metadata:
     peer: dc1-spine1
@@ -377,12 +377,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan11
   description: VRF10_VLAN11
@@ -405,7 +405,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF10
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -431,7 +431,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF11
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-spine1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.0/31
   metadata:
     peer: dc1-leaf1a
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_dc1-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.2/31
   metadata:
     peer: dc1-leaf1b
@@ -39,7 +39,7 @@ ethernet_interfaces:
 - name: Ethernet3
   description: P2P_dc1-svc-leaf1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.82/31
   metadata:
     peer: dc1-svc-leaf1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-svc-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/dc1-svc-leaf1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_dc1-spine1_Ethernet3
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.83/31
   metadata:
     peer: dc1-spine1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-leaf1a.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htft-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.1/31
   metadata:
     peer: htft-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htft-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.3/31
   metadata:
     peer: htft-spine2
@@ -245,12 +245,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-leaf1b.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htft-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.5/31
   metadata:
     peer: htft-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htft-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.7/31
   metadata:
     peer: htft-spine2
@@ -245,12 +245,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-spine1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-spine1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htft-leaf1a_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.0/31
   metadata:
     peer: htft-leaf1a
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htft-leaf1b_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.4/31
   metadata:
     peer: htft-leaf1b

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-spine2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htft-spine2.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htft-leaf1a_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.2/31
   metadata:
     peer: htft-leaf1a
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htft-leaf1b_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.6/31
   metadata:
     peer: htft-leaf1b

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-leaf1.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htipa-spine1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.1/31
   metadata:
     peer: htipa-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htipa-spine2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.3/31
   metadata:
     peer: htipa-spine2
@@ -245,12 +245,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.3.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.3.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-leaf2.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htipa-spine1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.5/31
   metadata:
     peer: htipa-spine1
@@ -48,7 +48,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htipa-spine2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.7/31
   metadata:
     peer: htipa-spine2
@@ -245,12 +245,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.3.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.3.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-spine1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-spine1.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htipa-leaf1_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.0/31
   metadata:
     peer: htipa-leaf1
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htipa-leaf2_Ethernet1
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.4/31
   metadata:
     peer: htipa-leaf2

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-spine2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htipa-spine2.yml
@@ -17,7 +17,7 @@ ethernet_interfaces:
 - name: Ethernet1
   description: P2P_htipa-leaf1_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.2/31
   metadata:
     peer: htipa-leaf1
@@ -28,7 +28,7 @@ ethernet_interfaces:
 - name: Ethernet2
   description: P2P_htipa-leaf2_Ethernet2
   shutdown: false
-  mtu: 1500
+  mtu: 9214
   ip_address: 10.255.255.6/31
   metadata:
     peer: htipa-leaf2

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htns-l3-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htns-l3-leaf1.yml
@@ -306,12 +306,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.64/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan200
   description: Dev_App1
@@ -328,7 +328,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF_DEVELOPMENT
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1
@@ -362,7 +362,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF_PRODUCTION
   ip_address: 10.255.1.96/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htns-l3-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htns-l3-leaf2.yml
@@ -220,12 +220,12 @@ vlan_interfaces:
   description: MLAG_L3
   shutdown: false
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
 - name: Vlan4094
   description: MLAG
   shutdown: false
   ip_address: 10.255.1.65/31
-  mtu: 1500
+  mtu: 9214
   no_autostate: true
 - name: Vlan200
   description: Dev_App1
@@ -242,7 +242,7 @@ vlan_interfaces:
   shutdown: false
   vrf: VRF_DEVELOPMENT
   ip_address: 10.255.1.97/31
-  mtu: 1500
+  mtu: 9214
   metadata:
     tenants:
     - TENANT1

--- a/docs/howto/fabric_topology/README.md
+++ b/docs/howto/fabric_topology/README.md
@@ -58,7 +58,6 @@ ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HT
 1. `fabric_name` must be defined and match group name covering all devices in scope of the fabric.
 2. Underlay routing protocol - eBGP is common for EVPN/VXLAN fabrics
 3. Overlay routing protocol for EVPN peering
-4. MTU for point-to-point uplinks (1500 for virtual, 9214 for physical)
 
 ### Default Interfaces
 

--- a/docs/howto/fabric_topology/artifacts/htft-leaf1a-links.cfg
+++ b/docs/howto/fabric_topology/artifacts/htft-leaf1a-links.cfg
@@ -8,14 +8,14 @@ interface Port-Channel3
 interface Ethernet1
    description P2P_htft-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_htft-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !

--- a/docs/howto/fabric_topology/artifacts/htft-spine1-links.cfg
+++ b/docs/howto/fabric_topology/artifacts/htft-spine1-links.cfg
@@ -1,14 +1,14 @@
 interface Ethernet1
    description P2P_htft-leaf1a_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.0/31
 !
 interface Ethernet2
    description P2P_htft-leaf1b_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.4/31
 !

--- a/docs/howto/ip_addressing/artifacts/leaf1-to-spines.cfg
+++ b/docs/howto/ip_addressing/artifacts/leaf1-to-spines.cfg
@@ -1,14 +1,14 @@
 interface Ethernet1
    description P2P_htipa-spine1_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.1/31
 !
 interface Ethernet2
    description P2P_htipa-spine2_Ethernet1
    no shutdown
-   mtu 1500
+   mtu 9214
    no switchport
    ip address 10.255.255.3/31
 !


### PR DESCRIPTION
## Change Summary

Remove the explicit `p2p_uplinks_mtu: 1500` setting and associated vEOS/cEOS lab disclaimer comments from all examples and how-to guides, allowing the schema default of 9214 to apply.

## Related Issue(s)

Fixes #5706

## Component(s) name

`Docs`

## Proposed changes

Following the recommendation from @ClausHolbechArista, instead of changing `p2p_uplinks_mtu` from 1500 to 9214, the MTU setting is **removed entirely** so the schema default (9214) applies automatically. This also lets platform-specific defaults (e.g., CloudEOS → 9194) work without explicit overrides.

**Input files changed (8 group_vars + 2 docs):**

- `examples/single-dc-l3ls/group_vars/FABRIC/fabric_variables.yml` — removed `p2p_uplinks_mtu: 1500` + comments
- `examples/single-dc-l3ls-ipv6/group_vars/FABRIC/fabric_variables.yml` — same
- `examples/dual-dc-l3ls/group_vars/FABRIC.yml` — same
- `examples/l2ls-fabric/group_vars/DC1.yml` — removed override header + `p2p_uplinks_mtu: 1500`
- `examples/campus-fabric/group_vars/DC1_FABRIC.yml` — same
- `examples/isis-ldp-ipvpn/group_vars/WAN1.yml` — removed `mtu: 1500` + vEOS disclaimer from `p2p_links_profile`
- `extensions/molecule/howto/.../HTFT/fabric.yml` — removed `p2p_uplinks_mtu: 1500` + comment
- `extensions/molecule/howto/.../FABRIC/fabric_variables.yml` — removed `p2p_uplinks_mtu: 1500` + comments
- `docs/howto/fabric_topology/README.md` — removed footnote about MTU 1500/9214
- `examples/isis-ldp-ipvpn/README.md` — removed `p2p_uplinks_mtu` line, footnote, and `mtu: 1500` from core_profile

**Generated files regenerated (178 files):**

All `intended/configs/*.cfg`, `intended/structured_configs/*.yml`, and `documentation/devices/*.md` across all 6 examples and the howto molecule inventory. How-to guide artifact `.cfg` files under `docs/howto/` also regenerated.

## How to test

1. Verify no `p2p_uplinks_mtu: 1500` remains in any example or howto group_vars
2. Verify generated configs now show `mtu 9214` on P2P uplink interfaces (the schema default)
3. Remaining `mtu 1500` references are only on inband management SVIs (controlled by `inband_mgmt_mtu`, unrelated)
4. Run molecule scenarios for affected examples to confirm idempotency

## Checklist

### User Checklist

- [x] Removed `p2p_uplinks_mtu: 1500` from all 6 examples and 2 howto source files
- [x] Updated documentation (README footnotes and inline comments)
- [x] Regenerated all intended configs, structured configs, documentation, and howto artifacts

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and the documentation has been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly.