### PR TITLE
CI: Fix molecule and sanity test failures for ansible-core milestone

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -309,6 +309,8 @@ jobs:
           python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
+        env:
+          ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
         run: |
           molecule test --scenario-name ${{ matrix.avd_scenario }}
       - name: Check GIT status
@@ -415,7 +417,7 @@ jobs:
           - ansibe_version: stable
             pip_installation: "ansible-core<2.21.0"
           - ansibe_version: devel
-            pip_installation: "--user https://github.com/ansible/ansible/archive/devel.tar.gz"
+            pip_installation: "--user https://github.com/ansible/ansible/archive/milestone.tar.gz"
             skip_test: "--skip-test ansible-doc"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -437,7 +437,7 @@ jobs:
           path: /tmp/pyavd/
       - name: Install pyavd and Ansible requirements
         run: |
-          pip install  ${{ matrix.pip_installation }} "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]"
+          pip install "${{ matrix.pip_installation }}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]"
       - name: Run ansible-test sanity
         working-directory: ansible_collections/arista/avd
         # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -417,7 +417,7 @@ jobs:
           - ansibe_version: stable
             pip_installation: "ansible-core<2.21.0"
           - ansibe_version: devel
-            pip_installation: "--user https://github.com/ansible/ansible/archive/milestone.tar.gz"
+            pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
             skip_test: "--skip-test ansible-doc"
     steps:
       - uses: actions/checkout@v6

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.22.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.22.txt
@@ -1,0 +1,10 @@
+plugins/modules/eos_designs_documentation.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_structured_config.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
+plugins/vars/global_vars.py validate-modules:missing-gplv3-license
+plugins/modules/cv_workflow.py validate-modules:missing-gplv3-license
+plugins/modules/eos_cli_config_gen.py validate-modules:missing-gplv3-license
+plugins/modules/anta_workflow.py validate-modules:missing-gplv3-license
+plugins/modules/validate_inputs.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

Fix molecule and sanity test failures for ansible-core milestone

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`CI`

## Proposed changes

- Added env variable `ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore`.
- Updated the sanity job's devel pip installation from `ansible/ansible@devel` to `ansible/ansible@milestone`.
- Added `ignore-2.22.txt` sanity ignore file with missing-gplv3-license entries for all affected plugins.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
