### PR TITLE
CI: Added fabric_topology how-to to destroy

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
@@ -24,6 +24,7 @@
         state: absent
       with_items:
         - connected_endpoints/artifacts
+        - fabric_topology/artifacts
         - ip_addressing/artifacts
         - ipv6_numbered/artifacts
         - network_services/artifacts


### PR DESCRIPTION
## Change Summary

Add missing fabric_topology path to destroy in molecule

## Component(s) name

Molecule

## Proposed changes

Added to destroy.yml

## How to test

Run destroy locally and see artifacts removed `molecule destroy -s howto`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
