### PR TITLE
Feat(eos_cli_config_gen): Added the support of TLS for AAA server group RADIUS

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1646,23 +1646,25 @@ ip radius vrf abc source-interface Loopback10
 
 #### AAA Server Groups Summary
 
-| Server Group Name | Type | VRF | IP address |
-| ----------------- | ---- | --- | ---------- |
-| TACACS | tacacs+ | mgt | 10.10.11.157 |
-| TACACS | tacacs+ | default | 10.10.11.249 |
-| TACACS1 | tacacs+ | mgt | 10.10.10.157 |
-| TACACS1 | tacacs+ | default | 10.10.10.249 |
-| TACACS2 | tacacs+ | mgt | 192.168.10.157 |
-| TACACS2 | tacacs+ | default | 10.10.10.248 |
-| LDAP1 | ldap | mgt | 192.168.10.157 |
-| LDAP1 | ldap | default | 10.10.10.248 |
-| LADP2 | ldap | mgt | 10.10.10.157 |
-| LADP2 | ldap | default | 10.10.10.249 |
-| RADIUS1 | radius | mgt | 192.168.10.157 |
-| RADIUS1 | radius | default | 10.10.10.248 |
-| RADIUS2 | radius | mgt | 10.10.10.157 |
-| RADIUS2 | radius | default | 10.10.10.249 |
-| RADIUS3 | radius | - | - |
+| Server Group Name | Type | VRF | IP address | TLS Enabled | TLS Port |
+| ----------------- | ---- | --- | ---------- | ----------- | -------- |
+| TACACS | tacacs+ | mgt | 10.10.11.157 | - | - |
+| TACACS | tacacs+ | default | 10.10.11.249 | - | - |
+| TACACS1 | tacacs+ | mgt | 10.10.10.157 | - | - |
+| TACACS1 | tacacs+ | default | 10.10.10.249 | - | - |
+| TACACS2 | tacacs+ | mgt | 192.168.10.157 | - | - |
+| TACACS2 | tacacs+ | default | 10.10.10.248 | - | - |
+| LDAP1 | ldap | mgt | 192.168.10.157 | - | - |
+| LDAP1 | ldap | default | 10.10.10.248 | - | - |
+| LADP2 | ldap | mgt | 10.10.10.157 | - | - |
+| LADP2 | ldap | default | 10.10.10.249 | - | - |
+| RADIUS1 | radius | mgt | 192.168.10.157 | - | - |
+| RADIUS1 | radius | default | 10.10.10.248 | - | - |
+| RADIUS1 | radius | mgt | 11.11.11.123 | True | 2086 |
+| RADIUS2 | radius | mgt | 10.10.10.157 | - | - |
+| RADIUS2 | radius | default | 10.10.10.249 | - | - |
+| RADIUS2 | radius | default | 12.12.12.145 | True | - |
+| RADIUS3 | radius | - | - | - | - |
 
 #### AAA Server Groups Device Configuration
 
@@ -1679,10 +1681,12 @@ aaa group server ldap LDAP1
 aaa group server radius RADIUS1
    server 192.168.10.157 vrf mgt
    server 10.10.10.248
+   server 11.11.11.123 vrf mgt tls port 2086
 !
 aaa group server radius RADIUS2
    server 10.10.10.157 vrf mgt
    server 10.10.10.249
+   server 12.12.12.145 tls
 !
 aaa group server radius RADIUS3
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1890,10 +1890,12 @@ radius-server host 10.10.11.158 vrf mgt tls ssl-profile SSL_PROFILE
 aaa group server radius RADIUS1
    server 192.168.10.157 vrf mgt
    server 10.10.10.248
+   server 11.11.11.123 vrf mgt tls port 2086
 !
 aaa group server radius RADIUS2
    server 10.10.10.157 vrf mgt
    server 10.10.10.249
+   server 12.12.12.145 tls
 !
 aaa group server radius RADIUS3
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/aaa-server-groups.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/aaa-server-groups.yml
@@ -37,11 +37,19 @@ aaa_server_groups:
       - server: 192.168.10.157
         vrf: mgt
       - server: 10.10.10.248
+      - server: 11.11.11.123
+        vrf: mgt
+        tls:
+          enabled: true
+          port: 2086
   - name: RADIUS2
     type: radius
     servers:
       - server: 10.10.10.157
         vrf: mgt
       - server: 10.10.10.249
+      - server: 12.12.12.145
+        tls:
+          enabled: true
   - name: RADIUS3
     type: radius

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-server-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-server-groups.md
@@ -15,7 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls</samp>](## "aaa_server_groups.[].servers.[].tls") | Dictionary |  |  |  | TLS settings for the RADIUS group server. Only applicable when the parent server group type is 'radius'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "aaa_server_groups.[].servers.[].tls.enabled") | Boolean | Required |  |  | Enable TLS to secure communication with the RADIUS group server. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "aaa_server_groups.[].servers.[].tls.port") | Integer |  |  | Min: 0<br>Max: 65535 | TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "aaa_server_groups.[].servers.[].tls.port") | Integer |  |  | Min: 1<br>Max: 65535 | TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083). |
 
 === "YAML"
 
@@ -40,5 +40,5 @@
               enabled: <bool; required>
 
               # TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083).
-              port: <int; 0-65535>
+              port: <int; 1-65535>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-server-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-server-groups.md
@@ -13,6 +13,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;servers</samp>](## "aaa_server_groups.[].servers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;server</samp>](## "aaa_server_groups.[].servers.[].server") | String | Required |  |  | Hostname or IP address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "aaa_server_groups.[].servers.[].vrf") | String |  |  |  | VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tls</samp>](## "aaa_server_groups.[].servers.[].tls") | Dictionary |  |  |  | TLS settings for the RADIUS group server. Only applicable when the parent server group type is 'radius'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "aaa_server_groups.[].servers.[].tls.enabled") | Boolean | Required |  |  | Enable TLS to secure communication with the RADIUS group server. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "aaa_server_groups.[].servers.[].tls.port") | Integer |  |  | Min: 0<br>Max: 65535 | TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083). |
 
 === "YAML"
 
@@ -29,4 +32,13 @@
 
             # VRF name.
             vrf: <str>
+
+            # TLS settings for the RADIUS group server. Only applicable when the parent server group type is 'radius'.
+            tls:
+
+              # Enable TLS to secure communication with the RADIUS group server.
+              enabled: <bool; required>
+
+              # TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083).
+              port: <int; 0-65535>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/aaa-server-groups.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/aaa-server-groups.j2
@@ -17,12 +17,11 @@
 {%             if aaa_server_group.servers is arista.avd.defined %}
 {%                 for server in aaa_server_group.servers %}
 {%                     set vrf = server.vrf | arista.avd.default('default') %}
+{%                     set tls = "-" %}
+{%                     set tls_port = "-" %}
 {%                     if aaa_server_group.type is arista.avd.defined("radius") and server.tls is arista.avd.defined %}
 {%                         set tls = server.tls.enabled %}
 {%                         set tls_port = server.tls.port | arista.avd.default("-") %}
-{%                     else %}
-{%                         set tls = "-" %}
-{%                         set tls_port = "-" %}
 {%                     endif %}
 | {{ aaa_server_group.name }} | {{ aaa_server_group.type }} | {{ vrf }} | {{ server.server }} | {{ tls }} | {{ tls_port }} |
 {%                 endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/aaa-server-groups.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/aaa-server-groups.j2
@@ -10,17 +10,24 @@
 
 #### AAA Server Groups Summary
 
-| Server Group Name | Type | VRF | IP address |
-| ----------------- | ---- | --- | ---------- |
+| Server Group Name | Type | VRF | IP address | TLS Enabled | TLS Port |
+| ----------------- | ---- | --- | ---------- | ----------- | -------- |
 {%     for aaa_server_group in aaa_server_groups %}
 {%         if aaa_server_group.type is arista.avd.defined %}
 {%             if aaa_server_group.servers is arista.avd.defined %}
 {%                 for server in aaa_server_group.servers %}
 {%                     set vrf = server.vrf | arista.avd.default('default') %}
-| {{ aaa_server_group.name }} | {{ aaa_server_group.type }} | {{ vrf }} | {{ server.server }} |
+{%                     if aaa_server_group.type is arista.avd.defined("radius") and server.tls is arista.avd.defined %}
+{%                         set tls = server.tls.enabled %}
+{%                         set tls_port = server.tls.port | arista.avd.default("-") %}
+{%                     else %}
+{%                         set tls = "-" %}
+{%                         set tls_port = "-" %}
+{%                     endif %}
+| {{ aaa_server_group.name }} | {{ aaa_server_group.type }} | {{ vrf }} | {{ server.server }} | {{ tls }} | {{ tls_port }} |
 {%                 endfor %}
 {%             else %}
-| {{ aaa_server_group.name }} | {{ aaa_server_group.type }} | - | - |
+| {{ aaa_server_group.name }} | {{ aaa_server_group.type }} | - | - | - | - |
 {%             endif %}
 {%         endif %}
 {%     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/aaa-server-groups-radius.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/aaa-server-groups-radius.j2
@@ -13,6 +13,12 @@ aaa group server radius {{ aaa_server_group.name }}
 {%             if server.vrf is arista.avd.defined %}
 {%                 set server_cli = server_cli ~ " vrf " ~ server.vrf %}
 {%             endif %}
+{%             if server.tls.enabled is arista.avd.defined(true) %}
+{%                 set server_cli = server_cli ~ " tls" %}
+{%                 if server.tls.port is arista.avd.defined %}
+{%                     set server_cli = server_cli ~ " port " ~ server.tls.port %}
+{%                 endif %}
+{%             endif %}
    {{ server_cli }}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -1080,15 +1080,53 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class ServersItem(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"server": {"type": str}, "vrf": {"type": str}}
+            class Tls(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"enabled": {"type": bool}, "port": {"type": int}}
+                enabled: bool
+                """Enable TLS to secure communication with the RADIUS group server."""
+                port: int | None
+                """
+                TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default
+                is 2083).
+                """
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, enabled: bool | UndefinedType = Undefined, port: int | None | UndefinedType = Undefined) -> None:
+                        """
+                        Tls.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            enabled: Enable TLS to secure communication with the RADIUS group server.
+                            port:
+                               TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default
+                               is 2083).
+
+                        """
+
+            _fields: ClassVar[dict] = {"server": {"type": str}, "vrf": {"type": str}, "tls": {"type": Tls}}
             server: str
             """Hostname or IP address."""
             vrf: str | None
             """VRF name."""
+            tls: Tls
+            """
+            TLS settings for the RADIUS group server. Only applicable when the parent server group type is
+            'radius'.
+
+            Subclass of AvdModel.
+            """
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, server: str | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined) -> None:
+                def __init__(
+                    self, *, server: str | UndefinedType = Undefined, vrf: str | None | UndefinedType = Undefined, tls: Tls | UndefinedType = Undefined
+                ) -> None:
                     """
                     ServersItem.
 
@@ -1098,6 +1136,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Args:
                         server: Hostname or IP address.
                         vrf: VRF name.
+                        tls:
+                           TLS settings for the RADIUS group server. Only applicable when the parent server group type is
+                           'radius'.
+
+                           Subclass of AvdModel.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -444,7 +444,7 @@ keys:
                     required: true
                   port:
                     type: int
-                    min: 0
+                    min: 1
                     max: 65535
                     convert_types:
                     - str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -432,6 +432,24 @@ keys:
                 description: VRF name.
                 convert_types:
                 - int
+              tls:
+                type: dict
+                description: TLS settings for the RADIUS group server. Only applicable
+                  when the parent server group type is 'radius'.
+                keys:
+                  enabled:
+                    type: bool
+                    description: Enable TLS to secure communication with the RADIUS
+                      group server.
+                    required: true
+                  port:
+                    type: int
+                    min: 0
+                    max: 65535
+                    convert_types:
+                    - str
+                    description: TCP port used for TLS-secured RADIUS communication.
+                      Overrides the default RadSec port (EOS default is 2083).
   access_lists:
     type: list
     primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
@@ -33,3 +33,18 @@ keys:
                 description: VRF name.
                 convert_types:
                   - int
+              tls:
+                type: dict
+                description: TLS settings for the RADIUS group server. Only applicable when the parent server group type is 'radius'.
+                keys:
+                  enabled:
+                    type: bool
+                    description: Enable TLS to secure communication with the RADIUS group server.
+                    required: true
+                  port:
+                    type: int
+                    min: 0
+                    max: 65535
+                    convert_types:
+                      - str
+                    description: TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083).

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
@@ -43,7 +43,7 @@ keys:
                     required: true
                   port:
                     type: int
-                    min: 0
+                    min: 1
                     max: 65535
                     convert_types:
                       - str


### PR DESCRIPTION
## Change Summary

Added the support of TLS for AAA server group RADIUS

## Related Issue(s)

Fixes #6823 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added the support of TLS for AAA server group RADIUS.
```
aaa_server_groups:
        # Group name.
      - name: <str; required; unique>
        type: <str; "tacacs+" | "radius" | "ldap"; required>
        servers:
            # Hostname or IP address.
          - server: <str; required>

            # VRF name.
            vrf: <str>

            # TLS settings for the RADIUS group server. Only applicable when the parent server group type is 'radius'.
            tls:

              # Enable TLS to secure communication with the RADIUS group server.
              enabled: <bool; required>

              # TCP port used for TLS-secured RADIUS communication. Overrides the default RadSec port (EOS default is 2083).
              port: <int; 0-65535>
```

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
