### PR TITLE
Refactor(plugins): Renaming AvdActionPlugin and AvdLoggingConfig to AVDActionPlugin and AVDLoggingConfig

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/validate_inputs.py
+++ b/ansible_collections/arista/avd/plugins/action/validate_inputs.py
@@ -24,7 +24,7 @@ from ansible_collections.arista.avd.plugins.plugin_utils.utils import (
     get_workers,
     parse_validation_result,
 )
-from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AvdActionPlugin, AvdLoggingConfig
+from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AVDActionPlugin, AVDLoggingConfig
 
 if TYPE_CHECKING:
     from pyavd_utils.validation import Configuration, ValidationResult, get_validated_data
@@ -175,10 +175,10 @@ def get_worker_hostvars() -> ActionPluginVars:
     return _HOSTVARS_MANAGER
 
 
-class ActionModule(AvdActionPlugin):
+class ActionModule(AVDActionPlugin):
     """Ansible Action Plugin for validating inputs against AVD schemas."""
 
-    _logging_config = AvdLoggingConfig(target_loggers=TARGET_LOGGERS)
+    _logging_config = AVDLoggingConfig(target_loggers=TARGET_LOGGERS)
 
     def main(self, task_vars: dict[str, Any]) -> None:
         """Execute the validate_inputs action plugin."""

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -19,7 +19,7 @@ from ansible.utils.collection_loader._collection_finder import _get_collection_m
 from ansible.utils.display import Display
 
 from ansible_collections.arista.avd.plugins import PYTHON_AVD_PATH, RUNNING_FROM_SOURCE
-from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AvdActionPlugin, AvdLoggingConfig
+from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AVDActionPlugin, AVDLoggingConfig
 
 if TYPE_CHECKING:
     # Relying on packaging installed by ansible
@@ -379,8 +379,8 @@ def check_running_from_source() -> bool:
     return schemas_recompiled or templates_recompiled
 
 
-class ActionModule(AvdActionPlugin):
-    _logging_config = AvdLoggingConfig(add_role_context=True)
+class ActionModule(AVDActionPlugin):
+    _logging_config = AVDLoggingConfig(add_role_context=True)
 
     def main(self, task_vars: dict[str, Any]) -> None:
         if not HAS_PACKAGING:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/__init__.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025-2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
-from .avd_action_plugin import AvdActionPlugin, AvdLoggingConfig
+from .avd_action_plugin import AVDActionPlugin, AVDLoggingConfig
 
-__all__ = ["AvdActionPlugin", "AvdLoggingConfig"]
+__all__ = ["AVDActionPlugin", "AVDLoggingConfig"]

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/avd_action_plugin.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/avd_action_plugin.py
@@ -12,15 +12,15 @@ from ansible.plugins.action import ActionBase
 
 from ansible_collections.arista.avd.plugins.plugin_utils.utils.raise_action_fail import raise_action_fail
 
-from .log_config import AvdLoggingConfig, LoggerState, get_avd_log_level
+from .log_config import AVDLoggingConfig, LoggerState, get_avd_log_level
 from .log_handlers import AnsibleDisplayHandler, ContextFilter, SaveToResultHandler
 
 
-class AvdActionPlugin(ActionBase):
+class AVDActionPlugin(ActionBase):
     """Base class for AVD Ansible action plugins to provide common functionality."""
 
     _primary_logger_name: ClassVar[str] = "ansible_collections.arista.avd"
-    _logging_config: ClassVar[AvdLoggingConfig] = AvdLoggingConfig()
+    _logging_config: ClassVar[AVDLoggingConfig] = AVDLoggingConfig()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the action plugin."""

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/log_config.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/log_config.py
@@ -96,7 +96,7 @@ def get_avd_log_level(logger_name: str) -> int:
 
 
 @dataclass(frozen=True)
-class AvdLoggingConfig:
+class AVDLoggingConfig:
     """Configuration for the logging environment in AVD Ansible action plugins."""
 
     add_role_context: bool = False

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
@@ -12,12 +12,12 @@ import pytest
 from ansible.errors import AnsibleActionFail
 from ansible.utils.display import Display
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AvdActionPlugin, AvdLoggingConfig
+from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AVDActionPlugin, AVDLoggingConfig
 from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin.log_handlers import AnsibleDisplayHandler
 
 
-class TestAvdActionPlugin:
-    """Test suite for the AvdActionPlugin base class."""
+class TestAVDActionPlugin:
+    """Test suite for the AVDActionPlugin base class."""
 
     @pytest.fixture
     def mock_display(self) -> Generator[MagicMock, Any, None]:
@@ -42,8 +42,8 @@ class TestAvdActionPlugin:
 
             yield shared_mock_instance
 
-    def _plugin_factory(self, cls: type[AvdActionPlugin], task_args: dict[str, Any] | None = None) -> AvdActionPlugin:
-        """Factory method to instantiate the provided AvdActionPlugin class with mocks for testing."""
+    def _plugin_factory(self, cls: type[AVDActionPlugin], task_args: dict[str, Any] | None = None) -> AVDActionPlugin:
+        """Factory method to instantiate the provided AVDActionPlugin class with mocks for testing."""
         # Create mock objects for the Ansible ActionBase constructor arguments
         mock_task = MagicMock()
         mock_task.args = task_args or {}
@@ -60,8 +60,8 @@ class TestAvdActionPlugin:
     def test_wrong_logging_config(self) -> None:
         """Test that an exception is raised when _primary_logger_name is not part of the targeted loggers."""
 
-        class ActionModule(AvdActionPlugin):
-            _logging_config = AvdLoggingConfig(target_loggers=("pyavd", "anta"))
+        class ActionModule(AVDActionPlugin):
+            _logging_config = AVDLoggingConfig(target_loggers=("pyavd", "anta"))
 
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
@@ -76,7 +76,7 @@ class TestAvdActionPlugin:
     def test_run_success(self) -> None:
         """Test a successful run of the plugin."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 self.result["status"] = "success"
@@ -91,7 +91,7 @@ class TestAvdActionPlugin:
     def test_run_failure_recast_as_ansible_exception(self) -> None:
         """Test that a generic exception in main() is recast as AnsibleActionFail."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 msg = "Something went wrong"
@@ -170,8 +170,8 @@ class TestAvdActionPlugin:
     def test_log_levels_set_by_verbosity(self, mock_display: MagicMock, verbosity: int, expected_levels: dict[str, int]) -> None:
         """Test that log levels are set correctly based on verbosity for both internal and external libraries."""
 
-        class ActionModule(AvdActionPlugin):
-            _logging_config = AvdLoggingConfig(target_loggers=tuple(expected_levels.keys()))
+        class ActionModule(AVDActionPlugin):
+            _logging_config = AVDLoggingConfig(target_loggers=tuple(expected_levels.keys()))
 
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
@@ -198,7 +198,7 @@ class TestAvdActionPlugin:
     def test_default_logging_behavior(self, mock_display: MagicMock, verbosity: int, expected_methods_called: list[str]) -> None:
         """Test the end-to-end default logging behavior (live display on, save logs off)."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 self.logger.debug("A debug message.")
@@ -248,8 +248,8 @@ class TestAvdActionPlugin:
     ) -> None:
         """Test that context variables are added and the log format is changed based on the logging config."""
 
-        class ActionModule(AvdActionPlugin):
-            _logging_config = AvdLoggingConfig(add_hostname_context=add_hostname, add_role_context=add_role)
+        class ActionModule(AVDActionPlugin):
+            _logging_config = AVDLoggingConfig(add_hostname_context=add_hostname, add_role_context=add_role)
 
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
@@ -267,7 +267,7 @@ class TestAvdActionPlugin:
     def test_logging_with_save_logs(self) -> None:
         """Test that logs are saved to the result."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 self.logger.warning("A warning to save.")
@@ -285,7 +285,7 @@ class TestAvdActionPlugin:
     def test_logging_with_live_display_false(self, mock_display: MagicMock) -> None:
         """Test that logs are never displayed in Ansible."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 self.logger.info("This should not be displayed live.")
@@ -310,7 +310,7 @@ class TestAvdActionPlugin:
     def test_warning_capture(self, warning_type: type[Warning], message: str, expected_key: str) -> None:
         """Test that Python warnings are captured and added to the correct list in the result."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
                 warnings.warn(message, warning_type, stacklevel=1)
@@ -328,7 +328,7 @@ class TestAvdActionPlugin:
     def test_handles_dirty_logger_state(self) -> None:
         """Test that the plugin can handle a logger with pre-existing handlers and restore them correctly upon exit."""
 
-        class ActionModule(AvdActionPlugin):
+        class ActionModule(AVDActionPlugin):
             def main(self, task_vars: dict[str, Any]) -> None:
                 _task_vars = task_vars
 


### PR DESCRIPTION
## Change Summary

First step from AVD plugin refactoring 

```
AvdActionPlugin and AvdLoggingConfig should be renamed AVDActionPlugin and AVDLoggingConfig to follow new naming convention enforcement.
```

## Related Issue(s)

Fixes -

## Component(s) name

`plugins`

## Proposed changes
-

## How to test
-

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
